### PR TITLE
[WIP] Add pre-commit config and installation notes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+- repo: local
+  hooks:
+  - id: npm-lint
+    name: npm lint
+    entry: sh -c 'npm run lint'
+    language: system
+    types: [file]
+    files: src/.*\.(cjs|js|ts|tsx|json|css|md|yml)$
+    pass_filenames: false
+  - id: npm-format
+    name: npm run format
+    entry: sh -c 'npm run format'
+    language: system
+    types: [file]
+    files: src/.*\.(cjs|js|ts|tsx|json|css|md|yml)$
+    pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Install with `npm install`
 Run the dev server with `npm run dev`
 
 See [scene.tsx](https://github.com/aganders3/points-web-viewer/blob/a66ff6aa7ff3cdf1259cf4090ac388ac59d85991/src/scene.tsx) for an example component displaying a three.js scene.
+
+To run linting and formatting run `npm run lint` and `npm run format`.
+To automate these as git pre-commit hooks run `pip install pre-commit && pre-commit install`.


### PR DESCRIPTION
This adds a `pre-commit` config file to the repo, so that contributors can run those hooks locally automatically when committing.

The configs are lifted from [the cryoet-data-portal repo](https://github.com/chanzuckerberg/cryoet-data-portal/blob/0141d70cfdd73ecc77355f16678862e61258f351/.pre-commit-config.yaml#L25).

I chose `pre-commit` (over something more JS like `husky`) because I have some familiarity with it and because it's plausible we might have some other languages in this repo (e.g. Python for generating synthetic data, converting real data, or hosting local files).

Here's some console output when making a change with broken formatting

```
(zebrahub-demo) ➜  points-web-viewer git:(pre-commit) ✗ git add src
(zebrahub-demo) ➜  points-web-viewer git:(pre-commit) ✗ git commit 
npm lint.................................................................Failed
- hook id: npm-lint
- exit code: 1

> three-experiments@0.0.0 lint
> eslint src


/Users/asweet/projects/points-web-viewer/src/PointCanvas.ts
  35:18  error  Insert `;`         prettier/prettier
  35:18  error  Missing semicolon  semi

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.


npm run format...........................................................Failed
- hook id: npm-format
- files were modified by this hook

> three-experiments@0.0.0 format
> prettier --write src

src/app.css 29ms (unchanged)
src/app.tsx 201ms (unchanged)
src/index.css 8ms (unchanged)
src/main.tsx 6ms (unchanged)
src/PointCanvas.ts 56ms
src/PointSelectionBox.ts 48ms (unchanged)
src/scene.tsx 40ms (unchanged)

(zebrahub-demo) ➜  points-web-viewer git:(pre-commit) ✗ git add src
(zebrahub-demo) ➜  points-web-viewer git:(pre-commit) ✗ git commit 
npm lint.................................................................Passed
npm run format...........................................................Passed
Aborting commit due to empty commit message.
```