### PR TITLE
Handle case when no missing index is found

### DIFF
--- a/src/scene.tsx
+++ b/src/scene.tsx
@@ -224,8 +224,10 @@ async function fetchPointsAtTime(array: ZarrArray, timeIndex: number): Promise<F
     // this is how the jagged array is stored in the zarr
     // for Float32 it's actually -9999, but the int8 data is -127
     let endIndex = points.findIndex((value) => value <= -127);
-    if (endIndex % 3 !== 0) {
-        console.error("invalid points - not divisible by 3");
+    if (endIndex === -1) {
+        endIndex = points.length;
+    } else if (endIndex % 3 !== 0) {
+        console.error("invalid points - %d not divisible by 3", endIndex);
         endIndex -= endIndex % 3;
     }
     return points.subarray(0, endIndex);


### PR DESCRIPTION
In principle, the one row of the zarr could be completely packed with data (i.e. no missing data with the `-9999.99` values). This change handles that case. I also added some extra info to the log in the failing case.