### PR TITLE
Fix images in docs

### DIFF
--- a/public/docs/file_format.md
+++ b/public/docs/file_format.md
@@ -75,7 +75,7 @@ The *presence* of a nonzero element in this graph represents a connection betwee
 corresponding column.
 
 <p align="center">
-  <img src="images/tracks-to-tracks.svg" width="75%">
+  <img src="/docs/images/tracks-to-tracks.svg" width="75%">
   <p align="center">
     <em>Figure 1 - structure of the</em> tracks_to_tracks <em>matrix. Diagonal elements are always
     present, meaning a track is always part of its own lineage. The value of each sparse element is
@@ -116,10 +116,10 @@ illustrate this. To load the *complete* lineage for a given tracklet, find its o
 tracklet and select any point in it.
 
 <p align="center">
-  <img src="images/tracklets.svg" width="45%">
+  <img src="/docs/images/tracklets.svg" width="45%">
   <br>
-  <img src="images/tracklets-selected-1.svg" width="45%">
-  <img src="images/tracklets-selected-0.svg" width="45%">
+  <img src="/docs/images/tracklets-selected-1.svg" width="45%">
+  <img src="/docs/images/tracklets-selected-0.svg" width="45%">
   <p align="center">
     <em>Figure 2 - lineage depends on which point is selected. (top) a cartoon depecting a group of
     related tracklets. (left) selecting points at earlier timepoints will load more descendent


### PR DESCRIPTION
There's an issue with the docs showing images. I think this is all sorted more easily with a different docs hosting (and/or build) system.

Visiting https://points-web-viewer.vercel.app/docs, you get redirected to https://points-web-viewer.vercel.app/docs#/ and the images (in the File Format docs) don't load.

If you visit https://points-web-viewer.vercel.app/docs/ (note trailing slash) you get redirected to https://points-web-viewer.vercel.app/docs/#/ and the images work.

This PR changes the paths to be absolute (relative to the domain), which should mostly fix it for now.