### PR TITLE
fix saving state if single cell is selected

### DIFF
--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -133,7 +133,7 @@ export class PointCanvas {
         state.pointBrightness = this.pointBrightness;
         state.showTracks = this.showTracks;
         state.showTrackHighlights = this.showTrackHighlights;
-        state.selectedPointIds = new Array(...this.selectedPointIds);
+        state.selectedPointIds = Array.from(this.selectedPointIds);
         state.cameraPosition = this.camera.position.toArray();
         state.cameraTarget = this.controls.target.toArray();
         return state;


### PR DESCRIPTION
When only a single cell is selected, and the 'state' is saved by copying the URL, there is a bug. 
To be precise, `new Array(...this.selectedPointIds)' doesn't work when `this.selectedPointIds` is a `Set()` with only 1 element. 