### PR TITLE
Keep selection information box always open

### DIFF
--- a/src/components/leftSidebar/LeftSidebarWrapper.tsx
+++ b/src/components/leftSidebar/LeftSidebarWrapper.tsx
@@ -28,7 +28,7 @@ export default function LeftSidebarWrapper({
 }: LeftSidebarWrapperProps) {
     return (
         <>
-            {hasTracks ? (
+            {hasTracks && (
                 <TrackControls
                     trackManager={trackManager}
                     trackHighlightLength={trackHighlightLength}
@@ -38,9 +38,8 @@ export default function LeftSidebarWrapper({
                     setShowTrackHighlights={setShowTrackHighlights}
                     setTrackHighlightLength={setTrackHighlightLength}
                 />
-            ) : (
-                <ControlInstructions selectionMode={selectionMode} />
             )}
+            <ControlInstructions selectionMode={selectionMode} />
         </>
     );
 }


### PR DESCRIPTION
Before, the info box that explains how the user can select points disappears as soon as points are selected. In my experience, the selection key-combinations for the spherical selectors are quite complex, so it would be nice to keep them open. 

This PR always keeps the selection information box open