### PR TITLE
Prevent loading indicator from being hidden by parent

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -98,7 +98,7 @@ export default function App() {
 
     // this state is pure React
     const [playing, setPlaying] = useState(false);
-    const [isLoadingPoints, setIsLoadingPoints] = useState(false);
+    const [isLoadingPoints, setIsLoadingPoints] = useState(true);
     const [numLoadingTracks, setNumLoadingTracks] = useState(0);
 
     // refresh window to initial state
@@ -231,7 +231,7 @@ export default function App() {
             getPoints(canvas.curTime);
         } else {
             clearTimeout(loadingTimeout);
-            setIsLoadingPoints(false);
+            // setIsLoadingPoints(false);
             console.debug("IGNORE FETCH points at time %d", canvas.curTime);
         }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -347,7 +347,7 @@ export default function App() {
     };
 
     return (
-        <Box sx={{ display: "flex", flexDirection: "column", width: "100%", height: "100%", overflow: "hidden" }}>
+        <Box sx={{ display: "flex", flexDirection: "row", width: "100%", height: "100%", overflow: "hidden" }}>
             {/* TODO: components *could* go deeper still for organization */}
             {!detectedDevice.isPhone && (
                 <Drawer
@@ -480,7 +480,7 @@ export default function App() {
                     sx={{
                         flexGrow: 1,
                         width: "100%",
-                        height: "calc(100vh - 100px)", // Ensure canvas does not fill entire screen
+                        height: "100%",
                         overflow: "hidden",
                         position: "relative", // Add this to make ColorMap and TimestampOverlay relative to the canvas
                     }}
@@ -493,10 +493,10 @@ export default function App() {
                 {/* The playback controls */}
                 <Box
                     sx={{
-                        flexGrow: 0,
+                        flexGrow: 1,
                         padding: ".5em",
                         height: detectedDevice.isMobile ? "150px" : "50px", // leaving extra space for mobile
-                        paddingLeft: !detectedDevice.isPhone ? `${drawerWidth}px` : 0, // Ensure playback controls are visible
+                        paddingLeft: 0,
                     }}
                 >
                     <PlaybackControls

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -231,7 +231,7 @@ export default function App() {
             getPoints(canvas.curTime);
         } else {
             clearTimeout(loadingTimeout);
-            // setIsLoadingPoints(false);
+            // setIsLoadingPoints(false); // removed this line to make the loading indicated turn on from the beginning, until all points loaded
             console.debug("IGNORE FETCH points at time %d", canvas.curTime);
         }
 

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -18,10 +18,9 @@ const Scene = forwardRef(function SceneRender(props: SceneProps, ref: React.Ref<
                 flexGrow: 1,
                 width: "100%",
                 height: "100%",
-                overflow: "hidden",
             }}
         >
-            <Box sx={{ margin: "-5% auto", visibility: isLoading, zIndex: 1000, opacity: "70%" }}>
+            <Box sx={{ margin: "-3rem auto", visibility: isLoading, zIndex: 1000, opacity: "70%" }}>
                 <LoadingIndicator sdsStyle="tag" />
             </Box>
         </Box>


### PR DESCRIPTION
I'm not great with CSS - so not sure if this is the correct fix, but it brings back the loading indicator for me.

Note as mentioned in Slack it still appears centered on the _window_, when I think it should be centered on the _canvas_. I think this is because the canvas is still extending under the window.