### PR TITLE
disable selector buttons on iPad

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "inTRACKtive",
       "version": "0.0.0",
       "dependencies": {
-        "@czi-sds/components": "^21.4.0",
+        "@czi-sds/components": "^21.6.3",
         "@emotion/css": "^11.11.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@czi-sds/components": {
-      "version": "21.6.2",
-      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-21.6.2.tgz",
-      "integrity": "sha512-O4foAAn/U/ptFtEoyMNo9xHRFMZgzbZ/iUH5finctpqC3rvkVwbuh7TWkFB8cuoKKxpwaqTvBxzHFEtk5tWjrw==",
+      "version": "21.6.3",
+      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-21.6.3.tgz",
+      "integrity": "sha512-yGWeiIQjdrKOeoT9+J0GR6TYmXR6OxCwtWPun7fOCUW7y5C8cdQ0213/Udt5G0rsatdWzgxZr8TYoUFe9MQhig==",
       "license": "MIT",
       "peerDependencies": {
         "@emotion/css": "^11.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "inTRACKtive",
       "version": "0.0.0",
       "dependencies": {
-        "@czi-sds/components": "^20.0.1",
+        "@czi-sds/components": "^21.4.0",
         "@emotion/css": "^11.11.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -488,11 +488,11 @@
       }
     },
     "node_modules/@czi-sds/components": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-20.0.1.tgz",
-      "integrity": "sha512-vB3gGl+tzxDmV00J8ioLr/LIj1WU26448Pot9orgyGeZy+AaJM7WMT/qsSpPSCGEKLN5ykcIUBIDIGK1E/JZmQ==",
+      "version": "21.6.2",
+      "resolved": "https://registry.npmjs.org/@czi-sds/components/-/components-21.6.2.tgz",
+      "integrity": "sha512-O4foAAn/U/ptFtEoyMNo9xHRFMZgzbZ/iUH5finctpqC3rvkVwbuh7TWkFB8cuoKKxpwaqTvBxzHFEtk5tWjrw==",
+      "license": "MIT",
       "peerDependencies": {
-        "@emotion/core": "^11.0.0",
         "@emotion/css": "^11.11.2",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -533,12 +533,6 @@
         "@emotion/weak-memoize": "^0.3.1",
         "stylis": "4.2.0"
       }
-    },
-    "node_modules/@emotion/core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-11.0.0.tgz",
-      "integrity": "sha512-w4sE3AmHmyG6RDKf6mIbtHpgJUSJ2uGvPQb8VXFL7hFjMPibE8IiehG8cMX3Ztm4svfCQV6KqusQbeIOkurBcA==",
-      "peer": true
     },
     "node_modules/@emotion/css": {
       "version": "11.11.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@czi-sds/components": "^21.4.0",
+    "@czi-sds/components": "^21.6.3",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@czi-sds/components": "^20.0.1",
+    "@czi-sds/components": "^21.4.0",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/src/components/CellControls.tsx
+++ b/src/components/CellControls.tsx
@@ -21,8 +21,13 @@ interface CellControlsProps {
 
 export default function CellControls(props: CellControlsProps) {
     const buttonDefinition: SingleButtonDefinition[] = [
-        { icon: "Cube", tooltipText: "Box", value: PointSelectionMode.BOX },
-        { icon: "Starburst", tooltipText: "Sphere", value: PointSelectionMode.SPHERICAL_CURSOR },
+        { icon: "Cube", tooltipText: "Box", value: PointSelectionMode.BOX, disabled: props.isTablet },
+        {
+            icon: "Starburst",
+            tooltipText: "Sphere",
+            value: PointSelectionMode.SPHERICAL_CURSOR,
+            disabled: props.isTablet,
+        },
         { icon: "Globe", tooltipText: "Adjustable sphere", value: PointSelectionMode.SPHERE },
     ];
 

--- a/src/components/CellControls.tsx
+++ b/src/components/CellControls.tsx
@@ -31,20 +31,6 @@ export default function CellControls(props: CellControlsProps) {
         { icon: "Globe", tooltipText: "Adjustable sphere", value: PointSelectionMode.SPHERE },
     ];
 
-    // Intercept onChange of selection buttons to prevent the first two buttons from being selected on mobile devices
-    const handleSegmentedControlChange = (_e: React.MouseEvent<HTMLElement>, newValue: PointSelectionMode | null) => {
-        // If isTablet is true and the selected value corresponds to the first or second button, do nothing
-        if (
-            props.isTablet &&
-            (newValue === PointSelectionMode.BOX || newValue === PointSelectionMode.SPHERICAL_CURSOR)
-        ) {
-            window.alert("This selection mode is not available on mobile devices.");
-            console.log("Mobile device detected, preventing selection of box or spherical cursor");
-            return; // Prevent selection
-        }
-        props.setSelectionMode(newValue!); // Otherwise, update the selection mode
-    };
-
     return (
         <Stack spacing="1em">
             <Box display="flex" flexDirection="row" alignItems="center" justifyContent="space-between">
@@ -68,7 +54,9 @@ export default function CellControls(props: CellControlsProps) {
                 <SegmentedControl
                     id="selection-mode-control"
                     buttonDefinition={buttonDefinition}
-                    onChange={handleSegmentedControlChange}
+                    onChange={(_e, v) => {
+                        props.setSelectionMode(v);
+                    }}
                     value={props.selectionMode}
                 />
             </Box>

--- a/src/components/DataControls.tsx
+++ b/src/components/DataControls.tsx
@@ -143,7 +143,13 @@ export default function DataControls(props: DataControlsProps) {
             </Snackbar>
 
             <Tooltip title="Change link to another dataset">
-                <Button icon="GlobeBasic" sdsSize="large" sdsType="secondary" onClick={showUrlPopover} />
+                <Button
+                    icon="GlobeBasic"
+                    sdsSize="large"
+                    sdsType="secondary"
+                    sdsStyle="icon"
+                    onClick={showUrlPopover}
+                />
             </Tooltip>
 
             <Popover

--- a/src/components/DataControls.tsx
+++ b/src/components/DataControls.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { Alert, Box, Popover, Snackbar, Stack, Tooltip } from "@mui/material";
 
-import { Button, ButtonIcon, InputText } from "@czi-sds/components";
+import { Button, InputText } from "@czi-sds/components";
 import { ControlLabel, Note } from "@/components/Styled";
 import { TrackManager } from "@/lib/TrackManager";
 
@@ -88,10 +88,11 @@ export default function DataControls(props: DataControlsProps) {
         >
             {/* TODO: make this do something */}
             <Tooltip title="More info">
-                <ButtonIcon
+                <Button
                     icon="InfoCircle"
                     sdsSize="large"
                     sdsType="secondary"
+                    sdsStyle="icon"
                     onClick={() => {
                         if (window.confirm("For documentation go to Github (click OK to open Github in a new tab)")) {
                             window.open("https://github.com/royerlab/inTRACKtive", "_blank");
@@ -101,15 +102,22 @@ export default function DataControls(props: DataControlsProps) {
             </Tooltip>
 
             <Tooltip title="Refresh page to initial settings">
-                <ButtonIcon icon="Refresh" sdsSize="large" sdsType="secondary" onClick={refreshPageCallBack} />
+                <Button
+                    icon="Refresh"
+                    sdsSize="large"
+                    sdsType="secondary"
+                    sdsStyle="icon"
+                    onClick={refreshPageCallBack}
+                />
             </Tooltip>
 
             <Tooltip title="Copy a shareable URL for this view to your clipboard">
                 <span>
-                    <ButtonIcon
+                    <Button
                         icon="Share"
                         sdsSize="large"
                         sdsType="secondary"
+                        sdsStyle="icon"
                         disabled={!props.trackManager}
                         onClick={copyShareableUrlToClipBoard}
                     />
@@ -135,7 +143,7 @@ export default function DataControls(props: DataControlsProps) {
             </Snackbar>
 
             <Tooltip title="Change link to another dataset">
-                <ButtonIcon icon="GlobeBasic" sdsSize="large" sdsType="secondary" onClick={showUrlPopover} />
+                <Button icon="GlobeBasic" sdsSize="large" sdsType="secondary" onClick={showUrlPopover} />
             </Tooltip>
 
             <Popover
@@ -165,13 +173,13 @@ export default function DataControls(props: DataControlsProps) {
                         </label>
                         <InputText
                             id="data-url-input"
-                            autoFocus
+                            // autoFocus
                             label="Zarr URL"
                             hideLabel
                             placeholder={props.initialDataUrl}
                             defaultValue={props.dataUrl}
                             fullWidth={true}
-                            intent={props.trackManager ? "default" : "error"}
+                            intent={props.trackManager ? "default" : "negative"}
                         />
                         <Note>
                             <strong>Note:</strong> Changing this URL will replace the image and reset the canvas.

--- a/src/components/PlaybackControls.tsx
+++ b/src/components/PlaybackControls.tsx
@@ -1,5 +1,5 @@
 import { Box, Tooltip } from "@mui/material";
-import { ButtonIcon, InputSlider } from "@czi-sds/components";
+import { Button, InputSlider } from "@czi-sds/components";
 
 interface PlaybackControlsProps {
     enabled: boolean;
@@ -15,11 +15,11 @@ interface PlaybackControlsProps {
 export default function PlaybackControls(props: PlaybackControlsProps) {
     return (
         <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "2em" }}>
-            <ButtonIcon
+            <Button
                 icon="Play"
                 sdsSize="large"
-                sdsType="primary"
-                on={props.playing}
+                sdsType={props.playing ? "primary" : "secondary"} // Use a different `sdsType` to change color upon toggle
+                sdsStyle="icon"
                 disabled={!props.enabled}
                 onClick={() => props.setPlaying(!props.playing)}
             />
@@ -35,13 +35,12 @@ export default function PlaybackControls(props: PlaybackControlsProps) {
                 value={props.curTime}
                 sx={{ alignSelf: "flex-end" }}
             />
-            {/* TODO: add control button groups - perhaps a separate component */}
             <Tooltip title="Auto-rotate">
-                <ButtonIcon
+                <Button
                     icon="DNA"
                     sdsSize="large"
-                    sdsType="primary"
-                    on={props.autoRotate}
+                    sdsType={props.autoRotate ? "primary" : "secondary"} // Use a different `sdsType` to change color upon toggle
+                    sdsStyle="icon"
                     disabled={!props.enabled}
                     onClick={() => props.setAutoRotate(!props.autoRotate)}
                 />

--- a/src/components/leftSidebar/ControlInstructions.tsx
+++ b/src/components/leftSidebar/ControlInstructions.tsx
@@ -69,7 +69,7 @@ export default function ControlInstructions(props: ControlInstructionsProps) {
             break;
     }
     return (
-        <Callout intent="info" sx={{ width: "auto" }}>
+        <Callout intent="info" sx={{ width: "auto", maxWidth: "100%" }}>
             {instructionText}
         </Callout>
     );


### PR DESCRIPTION
Previously, the three selector buttons were always "active". On iPad we only want the third selector to be enabled (the orbit controls). I hacked around this solution by not propagating the button presses for the first two selectors when on iPad.

A cleaner solution would be to properly `disable` the buttons that should not be active. Recently, the `czi-sds/components` library has been updated to allow disabling buttons, as implemented in this PR.

- [x] ~The remaining problem now is that new new version of `SegmentedControl` in `czi-sds/components` no longer allows for deselecting all buttons, which we previously made use of. I am awaiting their response to an issue I created. Once I have more info, I will finish this PR.~