### PR TITLE
remove axes on phone

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -96,10 +96,6 @@ export default function App() {
     const numSelectedTracks = canvas.tracks.size;
     const trackHighlightLength = canvas.maxTime - canvas.minTime;
 
-    if (detectedDevice.isPhone) {
-        canvas.axesVisible = false;
-    }
-
     // this state is pure React
     const [playing, setPlaying] = useState(false);
     const [isLoadingPoints, setIsLoadingPoints] = useState(true);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -96,6 +96,10 @@ export default function App() {
     const numSelectedTracks = canvas.tracks.size;
     const trackHighlightLength = canvas.maxTime - canvas.minTime;
 
+    if (detectedDevice.isPhone) {
+        canvas.axesVisible = false;
+    }
+
     // this state is pure React
     const [playing, setPlaying] = useState(false);
     const [isLoadingPoints, setIsLoadingPoints] = useState(true);

--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -134,6 +134,14 @@ export class PointCanvas {
 
         // this.scene.add(new AxesHelper(0.2));
         this.setupAxesHelper();
+        // if (this.axesVisible==false){
+        //     this.toggleAxesHelper();
+        //     console.log('toggled')
+        // }
+        if (detectedDevice.isPhone) {
+            this.toggleAxesHelper();
+        }
+
         this.scene.add(this.points);
         this.scene.fog = new FogExp2(0x000000, 0.0005); // default is 0.00025
 
@@ -161,6 +169,8 @@ export class PointCanvas {
             this.setSelectionMode(PointSelectionMode.SPHERE);
         } else if (detectedDevice.isPhone) {
             this.setSelectionMode(null); // no selection functionality on phone
+            // this.axesVisible = false; // axes helper is not visible on phone
+            // console.log('axes set to false')
         } else {
             this.setSelectionMode(PointSelectionMode.BOX);
         }

--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -134,10 +134,6 @@ export class PointCanvas {
 
         // this.scene.add(new AxesHelper(0.2));
         this.setupAxesHelper();
-        // if (this.axesVisible==false){
-        //     this.toggleAxesHelper();
-        //     console.log('toggled')
-        // }
         if (detectedDevice.isPhone) {
             this.toggleAxesHelper();
         }
@@ -169,8 +165,6 @@ export class PointCanvas {
             this.setSelectionMode(PointSelectionMode.SPHERE);
         } else if (detectedDevice.isPhone) {
             this.setSelectionMode(null); // no selection functionality on phone
-            // this.axesVisible = false; // axes helper is not visible on phone
-            // console.log('axes set to false')
         } else {
             this.setSelectionMode(PointSelectionMode.BOX);
         }


### PR DESCRIPTION
Since the UI on the phone doesn't allow for toggling the XYZ-axis icon, let's just not plot the axes at all (to make the actual point better visible)