### PR TITLE
Hoover curson over cells for info

### DIFF
--- a/CONFIG.ts
+++ b/CONFIG.ts
@@ -1,3 +1,5 @@
+import { Preview } from "@mui/icons-material"
+
 const config = {
     // Customize the branding of the viewer by providing a logo and/or name (at least one of them)
     branding:{
@@ -11,7 +13,8 @@ const config = {
     // When opening the viewer, or refreshing the page, the viewer will revert to the following default dataset
     data:{
         // Default dataset URL (must be publically accessible)
-        default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
+        // default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
+        default_dataset: "https://public.czbiohub.org/royerlab/zoo/Ascidian/tracks_ascidian_bundle.zarr/"
     },
   
     // Default settings for certain parameters
@@ -32,7 +35,7 @@ const config = {
         highlight_point_color: [0.9, 0, 0.9], //pink
 
         // Point color (when selector hovers over)
-        preview_hightlight_point_color: [0.8, 0.8, 0], //yellow
+        preview_hightlight_point_color: [0.8, 0.8, 0.0], //yellow
 
     }
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,7 +15,7 @@ import { ViewerState, clearUrlHash } from "@/lib/ViewerState";
 import { TrackManager, loadTrackManager } from "@/lib/TrackManager";
 import { PointSelectionMode } from "@/lib/PointSelector";
 import LeftSidebarWrapper from "./leftSidebar/LeftSidebarWrapper";
-// import { TimestampOverlay } from "./overlays/TimestampOverlay";
+import { TimestampOverlay } from "./overlays/TimestampOverlay";
 import { ColorMap } from "./overlays/ColorMap";
 import { TrackDownloadData } from "./DownloadButton";
 
@@ -487,6 +487,7 @@ export default function App() {
                 >
                     <Scene isLoading={isLoadingPoints || numLoadingTracks > 0} />
                     {/* <TimestampOverlay timestamp={canvas.curTime} /> */}
+                    <TimestampOverlay timestamp={canvas.selector.sphereSelector.closestIndex} />
                     <ColorMap />
                 </Box>
 

--- a/src/components/overlays/TimestampOverlay.tsx
+++ b/src/components/overlays/TimestampOverlay.tsx
@@ -2,20 +2,20 @@ import { Tag } from "@czi-sds/components";
 import "@czi-sds/components/dist/variables.css";
 
 interface TimestampOverlayProps {
-    timestamp: number; // Currently timestamp is a frame number, but it could be the actual timestamp
+    timestamp: number | undefined; // Currently timestamp is a frame number, but it could be the actual timestamp
 }
 
 export const TimestampOverlay = (props: TimestampOverlayProps) => {
     return (
         <Tag
-            label={props.timestamp.toString()}
+            label={props.timestamp !== undefined ? `cell = ${props.timestamp.toString()}` : "-"}
             sdsStyle="square"
             sdsType="secondary"
             size="small"
             sx={{
                 position: "absolute",
                 bottom: "0.5rem",
-                left: "16.5rem",
+                left: "0.5rem",
                 backgroundColor: "rgba(255, 255, 255, 0.6)",
                 zIndex: 100,
                 borderRadius: "var(--sds-corner-m)",

--- a/src/lib/SpherePointSelector.ts
+++ b/src/lib/SpherePointSelector.ts
@@ -218,7 +218,7 @@ export class SpherePointSelector {
 
         const positions = geometry.getAttribute("position");
         const numPoints = positions.count;
-        let closestDistance: number = Infinity; 
+        let closestDistance: number = Infinity;
         let closestIndex: number = -1;
         for (let i = 0; i < numPoints; i++) {
             const x = positions.getX(i);


### PR DESCRIPTION
This draft PR shows a proof-of-principle to show information from cells when hoovering the cursor over the cells. 
Now, the cell ID is shown as information, but this could be any information. 

Some important ToDos for the future: 
- [ ] reduce/increase raycaster radius between two functionalities
- [ ] from cell ID (of points in this frame) to global ID of the cell
- [ ] make proper info Tag for cell Info (instead of hacking the timestampOverlay)
- [ ] make proper mouseEvent, now it hijacks the pointerMove 
- [ ] make action always available (now only Shift)
- [ ] move the action to the general selector (now only if sphericalSelector)
