### PR TITLE
pin python Zarr<3

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "scipy",
   "scikit-image",
   "pandas",
-  "zarr"
+  "zarr<3"
 ]
 
 [project.urls]


### PR DESCRIPTION
The release of Zarr 3 breaks the Zarr conversion script. Since most people use Zarr 2, let's set an upper bound on the Zarr version