### PR TITLE
fixed createHash function to include ColorByEvent

### DIFF
--- a/python/src/intracktive/createHash.py
+++ b/python/src/intracktive/createHash.py
@@ -19,6 +19,16 @@ def generate_viewer_state_hash(data_url: str) -> str:
         The inTRACKtive hash string (to be added to the URL).
     """
 
+
+    # Define the Python equivalent of DEFAULT_DROPDOWN_OPTION
+    default_dropdown_option = {
+        "name": "uniform",
+        "label": 0,
+        "type": "default",
+        "action": "default",
+        "numCategorical": None,  # Equivalent to undefined in TypeScript
+    }
+
     # Replicate the initial state based on your ViewerState defaults
     viewer_state = {
         "dataUrl": data_url,
@@ -35,7 +45,7 @@ def generate_viewer_state_hash(data_url: str) -> str:
         "pointSize": 0.1,
         "trackWidthFactor": 1,
         "colorBy": False,
-        # TODO: add colorByEvent
+        "colorByEvent": default_dropdown_option,
     }
 
     # Step 1: Serialize the viewer state to a JSON string

--- a/python/src/intracktive/createHash.py
+++ b/python/src/intracktive/createHash.py
@@ -19,7 +19,6 @@ def generate_viewer_state_hash(data_url: str) -> str:
         The inTRACKtive hash string (to be added to the URL).
     """
 
-
     # Define the Python equivalent of DEFAULT_DROPDOWN_OPTION
     default_dropdown_option = {
         "name": "uniform",

--- a/python/src/intracktive/examples/notebook1_inTRACKtive_from_notebook.ipynb
+++ b/python/src/intracktive/examples/notebook1_inTRACKtive_from_notebook.ipynb
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
     "zarr_dir = Path()\n",
     "# zarr_dir = '/path/on/your/computer/\n",
     "\n",
-    "# dataframe_to_browser(df, zarr_dir)"
+    "dataframe_to_browser(df, zarr_dir)"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[OPTIONAL] add attributes to color the cells (takes ~20 sec to run)"
+    "[OPTIONAL] add attributes to color the cells based on lineage (takes ~20 sec to run)"
    ]
   },
   {
@@ -110,13 +110,6 @@
     "# Open the data in inTRACKtive\n",
     "dataframe_to_browser(df2, zarr_dir, extra_cols=[\"lineage\"])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixing the example notebook that launched inTRACKtive from the notebook. Because the ViewerState has been updated to contain `ColorBy` and `ColorByEvent`, this was not yet reflected in `createHash`. This creates the wrong hash and is therefore unable to open inTRACKtive