### PR TITLE
Adding `.parquet` file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This approach consists of two steps: converting the tracking data into our speci
 For the first step, we assume your cell tracking data is saved as `tracks.csv` in the format as described above (5-6 columns, with column names: `track_id, t, (z), y, x, parent_track_id]`), where `z` is optional. This `tracks.csv` file can be converted to our Zarr format using the following command-line function (found in [/python/src/intracktive/convert.py](/python/src/intracktive/convert.py)):
 
 ```
-intracktive convert --csv_file /path/to/tracks.csv
+intracktive convert --input_file /path/to/tracks.csv
 ```
 
 This function converts `tracks.csv` to `tracks_bundle.zarr` (if interested, see the [Zarr format](public/docs/file_format.md)). Change `/path/to/tracks.csv` into the actual path to you `tracks.csv`. By default, `tracks_bundle.zarr` is saved in the same directory as `tracks.csv`, unless `--out_dir` is specified as the extra parameter to the function call (see the [function itself](python/src/intracktive/convert.py) for more details). The conversion script works for 2D and 3D datasets (when the column `z` is not present, a 2D dataset is assumed, i.e., all `z`-values will be set to 0)
@@ -114,7 +114,7 @@ This function converts `tracks.csv` to `tracks_bundle.zarr` (if interested, see 
 By default, all the cells are represented by equally-sized dots in `inTRACKtive`. The conversion script has the option of giving each cell a different size. For this: 1) make sure `tracks.csv` has an extra column named `radius`, and 2) use the flag `--add_radius` when calling the conversion script:
 
 ```
-intracktive convert --csv_file path/to/tracks.csv --add_radius
+intracktive convert --input_file path/to/tracks.csv --add_radius
 ```
 
 Or use `intracktive convert --help` for the documentation on the inputs and outputs
@@ -122,13 +122,13 @@ Or use `intracktive convert --help` for the documentation on the inputs and outp
 Additionally, inTRACKtive has the option of giving each cell a different color based on provided data attributes (see the example [Jupyter Notebook (`/napari/src/intracktive/examples`)](/python/src/intracktive/examples/notebook1_inTRACKtive_from_notebook.ipynb)). One can add any attributes to the Zarr file, as long as they are present as columns in the `tracks.csv` tracking data. Using the following command-line interface, you can add one/multiple/all columns as attributes to the data:
 ```
 #add specific column as attribute
-intracktive convert --csv_file path/to/file.csv --add_attribute cell_size
+intracktive convert --input_file path/to/file.csv --add_attribute cell_size
 
 #add multiple columns as attributes
-intracktive convert --csv_file path/to/file.csv --add_attribute cell_size,time,diameter,color
+intracktive convert --input_file path/to/file.csv --add_attribute cell_size,time,diameter,color
 
 #add all columns as attributes
-intracktive convert --csv_file path/to/tracks.csv --add_all_attributes
+intracktive convert --input_file path/to/tracks.csv --add_all_attributes
 ```
 When using `add_all_attributes`, the code will add all given columns as an attribute, apart from the default columns (`track_id`, `t`, `z`, `y`, `x`, and `parent_track_id`). If desired, one can manually add these columns as attributes using `add_attribute x`,  for example. The conversion script will detect whether each provided column represents a categorical or continuous attribute. This information is saved in the Zarr attributes information and loaded by inTRACKtive to use the appropriate colormap. 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In order to view your own cell tracking data with `inTRACKtive`, make sure your 
 |          3 |   4 | 419 | 398 | 302 |                 1 |
 ```
 
-where `track_id` is the label of each track (consistent over time), and `parent_track_id` the `track_id` of the parent cell after cell division. In this example, cell `1` divides into cells `2` and `3` in at `t=2`. Make sure that `t` is continuous and starts at `0` and that `track_id` is integer-valued and starts from `1`. The can be in a `csv` format, or `pandas.dataFrame`, or anything equivalent. We are working on conversion script from popular cell tracking algorithms into our format, they will be available soon.
+where `track_id` is the label of each track (consistent over time), and `parent_track_id` the `track_id` of the parent cell after cell division. In this example, cell `1` divides into cells `2` and `3` in at `t=2`. Make sure that `t` is continuous and starts at `0` and that `track_id` is integer-valued and starts from `1`. This can be in a `csv` format, or `pandas.dataFrame`, or anything equivalent. We are working on conversion script from popular cell tracking algorithms into our format, they will be available soon.
 
 For `inTRACKtive`, the data described above needs to be converted into our specialized Zarr format. We have python and command-line functions (see below at point _i_), while the napari and Jupyter Notebook solutions do this under the hood. 
 
@@ -103,7 +103,7 @@ pip install intracktive
 
 This approach consists of two steps: converting the tracking data into our specialized Zarr format, and hosting the data to make it accessible for the browser. 
 
-For the first step, we assume your cell tracking data is saved as `tracks.csv` in the format as described above (5-6 columns, with column names: `track_id, t, (z), y, x, parent_track_id]`), where `z` is optional. This `tracks.csv` file can be converted to our Zarr format using the following command-line function (found in [/python/src/intracktive/convert.py](/python/src/intracktive/convert.py)):
+For the first step, we assume your cell tracking data is saved as `tracks.csv` (or `tracks.parquet`) in the format as described above (5-6 columns, with column names: `track_id, t, (z), y, x, parent_track_id]`), where `z` is optional. This `tracks.csv` file can be converted to our Zarr format using the following command-line function (found in [/python/src/intracktive/convert.py](/python/src/intracktive/convert.py)):
 
 ```
 intracktive convert --input_file /path/to/tracks.csv

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
   "scipy",
   "scikit-image",
   "pandas",
-  "zarr<3"
+  "zarr<3",
+  "pyarrow",
 ]
 
 [project.urls]

--- a/python/src/intracktive/_tests/test_cli.py
+++ b/python/src/intracktive/_tests/test_cli.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import List
 
 import pandas as pd
-from intracktive.main import main
 import pytest
+from intracktive.main import main
 
 
 def _run_command(command_and_args: List[str]) -> None:

--- a/python/src/intracktive/_tests/test_cli.py
+++ b/python/src/intracktive/_tests/test_cli.py
@@ -3,6 +3,7 @@ from typing import List
 
 import pandas as pd
 from intracktive.main import main
+import pytest
 
 
 def _run_command(command_and_args: List[str]) -> None:
@@ -22,7 +23,7 @@ def test_convert_cli_simple(
     _run_command(
         [
             "convert",
-            "--csv_file",
+            "--input_file",
             str(tmp_path / "sample_data.csv"),
             "--out_dir",
             str(tmp_path),
@@ -40,7 +41,7 @@ def test_convert_cli_single_attribute(
     _run_command(
         [
             "convert",
-            "--csv_file",
+            "--input_file",
             str(tmp_path / "sample_data.csv"),
             "--out_dir",
             str(tmp_path),
@@ -60,7 +61,7 @@ def test_convert_cli_multiple_attributes(
     _run_command(
         [
             "convert",
-            "--csv_file",
+            "--input_file",
             str(tmp_path / "sample_data.csv"),
             "--out_dir",
             str(tmp_path),
@@ -80,7 +81,7 @@ def test_convert_cli_all_attributes(
     _run_command(
         [
             "convert",
-            "--csv_file",
+            "--input_file",
             str(tmp_path / "sample_data.csv"),
             "--out_dir",
             str(tmp_path),
@@ -99,11 +100,59 @@ def test_convert_cli_all_attributes_prenormalized(
     _run_command(
         [
             "convert",
-            "--csv_file",
+            "--input_file",
             str(tmp_path / "sample_data.csv"),
             "--out_dir",
             str(tmp_path),
             "--add_all_attributes",
             "--pre_normalized",
+        ]
+    )
+
+
+def test_convert_cli_invalid_format(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    invalid_file = tmp_path / "sample_data.txt"
+    df.to_csv(invalid_file, index=False)
+
+    with pytest.raises(ValueError):
+        _run_command(
+            [
+                "convert",
+                "--input_file",
+                str(invalid_file),
+                "--out_dir",
+                str(tmp_path),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    "file_format,save_method",
+    [
+        ("csv", "to_csv"),
+        ("parquet", "to_parquet"),
+    ],
+)
+def test_convert_cli_simple_file_formats(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+    file_format: str,
+    save_method: str,
+) -> None:
+    df = make_sample_data
+    input_file = tmp_path / f"sample_data.{file_format}"
+    getattr(df, save_method)(input_file, index=False)
+
+    _run_command(
+        [
+            "convert",
+            "--input_file",
+            str(input_file),
+            "--out_dir",
+            str(tmp_path),
         ]
     )

--- a/python/src/intracktive/_tests/test_convert.py
+++ b/python/src/intracktive/_tests/test_convert.py
@@ -31,23 +31,13 @@ def _evaluate(new_group: zarr.Group, old_group: zarr.Group) -> None:
             )
 
 
-@pytest.mark.parametrize(
-    "file_format,save_func",
-    [
-        ("csv", lambda df, path: df.to_csv(path, index=False)),
-        ("parquet", lambda df, path: df.to_parquet(path, index=False)),
-    ],
-)
 def test_actual_zarr_content(
     tmp_path: Path,
     make_sample_data: pd.DataFrame,
-    file_format: str,
-    save_func: callable,
 ) -> None:
     df = make_sample_data
     df["radius"] = np.linspace(10, 18, 5)
 
-    save_func(df, tmp_path / f"sample_data.{file_format}")
     new_path = tmp_path / "sample_data_bundle.zarr"
     gt_path = Path(__file__).parent / "data" / "gt_data_bundle.zarr"
 

--- a/python/src/intracktive/_tests/test_convert.py
+++ b/python/src/intracktive/_tests/test_convert.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import zarr
 from intracktive.convert import convert_dataframe_to_zarr
-import pytest
 
 
 def _evaluate(new_group: zarr.Group, old_group: zarr.Group) -> None:
@@ -31,13 +30,13 @@ def _evaluate(new_group: zarr.Group, old_group: zarr.Group) -> None:
             )
 
 
-def test_actual_zarr_content(
-    tmp_path: Path,
-    make_sample_data: pd.DataFrame,
-) -> None:
+def test_actual_zarr_content(tmp_path: Path, make_sample_data: pd.DataFrame) -> None:
     df = make_sample_data
     df["radius"] = np.linspace(10, 18, 5)
 
+    print("df", df)
+
+    df.to_csv(tmp_path / "sample_data.csv", index=False)
     new_path = tmp_path / "sample_data_bundle.zarr"
     gt_path = Path(__file__).parent / "data" / "gt_data_bundle.zarr"
 

--- a/python/src/intracktive/_tests/test_convert.py
+++ b/python/src/intracktive/_tests/test_convert.py
@@ -34,9 +34,6 @@ def test_actual_zarr_content(tmp_path: Path, make_sample_data: pd.DataFrame) -> 
     df = make_sample_data
     df["radius"] = np.linspace(10, 18, 5)
 
-    print("df", df)
-
-    df.to_csv(tmp_path / "sample_data.csv", index=False)
     new_path = tmp_path / "sample_data_bundle.zarr"
     gt_path = Path(__file__).parent / "data" / "gt_data_bundle.zarr"
 

--- a/python/src/intracktive/convert.py
+++ b/python/src/intracktive/convert.py
@@ -453,12 +453,14 @@ def convert_cli(
 
     # Read input file based on extension
     file_extension = input_file.suffix.lower()
-    if file_extension == '.csv':
+    if file_extension == ".csv":
         tracks_df = pd.read_csv(input_file)
-    elif file_extension == '.parquet':
+    elif file_extension == ".parquet":
         tracks_df = pd.read_parquet(input_file)
     else:
-        raise ValueError(f"Unsupported file format: {file_extension}. Only .csv and .parquet files are supported.")
+        raise ValueError(
+            f"Unsupported file format: {file_extension}. Only .csv and .parquet files are supported."
+        )
 
     LOG.info(f"Read {len(tracks_df)} points in {time.monotonic() - start} seconds")
 


### PR DESCRIPTION
Hi @TeunHuijben,

Because we are starting to use `.parquet` for larger tracking datasets, I think it would be nice for `inTRACKtive` to support it as well.
This PR implements this.

It changes the CLI interface, so I updated the README documentation, I think it deserves double checking if I didn't missing anything.

When implementing the tests, I noticed the `test_convert` is a bit misleading. I think these lines could be removed, but I didn't change them.

https://github.com/royerlab/inTRACKtive/blob/ce18ea2909a8d3edecbda6613a02c07709e6ef6f/python/src/intracktive/_tests/test_convert.py#L37-L39