### PR TITLE
Tracks.csv without parent_track_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In order to view your own cell tracking data with `inTRACKtive`, make sure your 
 |          3 |   4 | 419 | 398 | 302 |                 1 |
 ```
 
-where `track_id` is the label of each track (consistent over time), and `parent_track_id` the `track_id` of the parent cell after cell division. In this example, cell `1` divides into cells `2` and `3` in at `t=2`. Make sure that `t` is continuous and starts at `0` and that `track_id` is integer-valued and starts from `1`. This can be in a `csv` format, or `pandas.dataFrame`, or anything equivalent. We are working on conversion script from popular cell tracking algorithms into our format, they will be available soon.
+where `track_id` is the label of each track (consistent over time), and `parent_track_id` the `track_id` of the parent cell after cell division (a `parent_track_id` of `-1` indicates that the cell has no parent. The absence of this column in the tracking data assumes that there are no cell divisions). In this example, cell `1` divides into cells `2` and `3` in at `t=2`. Make sure that `t` is continuous and starts at `0` and that `track_id` is integer-valued and starts from `1`. This can be in a `csv` format, or `pandas.dataFrame`, or anything equivalent. We are working on conversion script from popular cell tracking algorithms into our format, they will be available soon.
 
 For `inTRACKtive`, the data described above needs to be converted into our specialized Zarr format. We have python and command-line functions (see below at point _i_), while the napari and Jupyter Notebook solutions do this under the hood. 
 
@@ -103,7 +103,7 @@ pip install intracktive
 
 This approach consists of two steps: converting the tracking data into our specialized Zarr format, and hosting the data to make it accessible for the browser. 
 
-For the first step, we assume your cell tracking data is saved as `tracks.csv` (or `tracks.parquet`) in the format as described above (5-6 columns, with column names: `track_id, t, (z), y, x, parent_track_id]`), where `z` is optional. This `tracks.csv` file can be converted to our Zarr format using the following command-line function (found in [/python/src/intracktive/convert.py](/python/src/intracktive/convert.py)):
+For the first step, we assume your cell tracking data is saved as `tracks.csv` (or `tracks.parquet`) in the format as described above (5-6 columns, with column names: `track_id, t, (z), y, x, (parent_track_id)]`), where `z` and `parent_track_id` are optional (no `z` column assumes 2D data, and no `parent_track_id` column assumes no cell divisions). This `tracks.csv` file can be converted to our Zarr format using the following command-line function (found in [/python/src/intracktive/convert.py](/python/src/intracktive/convert.py)):
 
 ```
 intracktive convert --input_file /path/to/tracks.csv

--- a/python/src/intracktive/convert.py
+++ b/python/src/intracktive/convert.py
@@ -115,6 +115,10 @@ def convert_dataframe_to_zarr(
         flag_2D = True
         df["z"] = 0.0
 
+    if "parent_track_id" not in df.columns:
+        LOG.info("No parent_track_id column found, setting to -1 (no divisions)")
+        df["parent_track_id"] = -1
+
     points_cols = (
         ["z", "y", "x", "radius"] if add_radius else ["z", "y", "x"]
     )  # columns to store in the points array

--- a/python/src/intracktive/server.py
+++ b/python/src/intracktive/server.py
@@ -112,9 +112,14 @@ def serve_directory(
     type=click.Path(exists=True, file_okay=False, path_type=Path),
 )
 @click.option(
-    "--host", type=str, default=DEFAULT_HOST, help="The host name or IP address."
+    "--host",
+    type=str,
+    default=DEFAULT_HOST,
+    help="The host name or IP address (default: 127.0.0.1)",
 )
-@click.option("--port", type=int, default=8000, help="The port number to serve on.")
+@click.option(
+    "--port", type=int, default=8000, help="The port number to serve on (default: 8000)"
+)
 def server_cli(
     path: Path,
     host: str,


### PR DESCRIPTION
When parent_track_id is missing as column in the input file, the conversion script set this column to -1, which means no divisions. 

This info is added to the `readme`