### PR TITLE
Fix selection of ghost cells

### DIFF
--- a/CONFIG.ts
+++ b/CONFIG.ts
@@ -11,8 +11,7 @@ const config = {
     // When opening the viewer, or refreshing the page, the viewer will revert to the following default dataset
     data:{
         // Default dataset URL (must be publically accessible)
-        // default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
-        default_dataset: "https://public.czbiohub.org/royerlab/zoo/C_elegans/tracks_elegans_bundle.zarr/"
+        default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
     },
   
     // Default settings for certain parameters

--- a/CONFIG.ts
+++ b/CONFIG.ts
@@ -11,7 +11,8 @@ const config = {
     // When opening the viewer, or refreshing the page, the viewer will revert to the following default dataset
     data:{
         // Default dataset URL (must be publically accessible)
-        default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
+        // default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
+        default_dataset: "https://public.czbiohub.org/royerlab/zoo/C_elegans/tracks_elegans_bundle.zarr/"
     },
   
     // Default settings for certain parameters

--- a/src/hooks/usePointCanvas.ts
+++ b/src/hooks/usePointCanvas.ts
@@ -216,6 +216,8 @@ function reducer(canvas: PointCanvas, action: PointCanvasAction): PointCanvas {
             if (typeof action.curTime === "function") {
                 action.curTime = action.curTime(canvas.curTime);
             }
+            // Clear points before time change
+            newCanvas.clearPointsGeometry();
             newCanvas.curTime = action.curTime;
             newCanvas.minTime += action.curTime - canvas.curTime;
             newCanvas.maxTime += action.curTime - canvas.curTime;

--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -586,6 +586,9 @@ export class PointCanvas {
     }
 
     setPointsPositions(data: Float32Array) {
+        // Clear existing geometry first
+        this.clearPointsGeometry();
+
         const numPoints = data.length / numberOfValuesPerPoint;
         const geometry = this.points.geometry;
         const positions = geometry.getAttribute("position");
@@ -707,6 +710,23 @@ export class PointCanvas {
             } else {
                 this.scene.remove(this.axesHelper); // Remove from the scene if not visiblev
             }
+        }
+    }
+
+    clearPointsGeometry() {
+        const geometry = this.points.geometry;
+        // Set draw range to 0 to effectively hide all points
+        geometry.setDrawRange(0, 0);
+        // Clear the position attribute
+        const positions = geometry.getAttribute("position");
+        if (positions) {
+            positions.array.fill(0);
+            positions.needsUpdate = true;
+        }
+        // Force a refresh of the sphere selector if it's active
+        if (this.selector.selectionMode === PointSelectionMode.SPHERE || 
+            this.selector.selectionMode === PointSelectionMode.SPHERICAL_CURSOR) {
+            this.selector.sphereSelector.findPointsWithinSelector();
         }
     }
 }

--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -713,6 +713,7 @@ export class PointCanvas {
         }
     }
 
+    // Clear the points geometry when the timepoint changes
     clearPointsGeometry() {
         const geometry = this.points.geometry;
         // Set draw range to 0 to effectively hide all points
@@ -724,8 +725,10 @@ export class PointCanvas {
             positions.needsUpdate = true;
         }
         // Force a refresh of the sphere selector if it's active
-        if (this.selector.selectionMode === PointSelectionMode.SPHERE || 
-            this.selector.selectionMode === PointSelectionMode.SPHERICAL_CURSOR) {
+        if (
+            this.selector.selectionMode === PointSelectionMode.SPHERE ||
+            this.selector.selectionMode === PointSelectionMode.SPHERICAL_CURSOR
+        ) {
             this.selector.sphereSelector.findPointsWithinSelector();
         }
     }

--- a/src/lib/SpherePointSelector.ts
+++ b/src/lib/SpherePointSelector.ts
@@ -213,10 +213,21 @@ export class SpherePointSelector {
         normalMatrix.invert();
         const center = this.cursor.position;
         const geometry = this.points.geometry;
+
+        // Check if geometry has a valid 'position' attribute
+        if (!geometry || !geometry.getAttribute("position") || geometry.getAttribute("position").count === 0) {
+            return;
+        }
+
         const positions = geometry.getAttribute("position");
-        const numPoints = positions.count;
+        // Get the draw range which indicates which points are actually active
+        const drawRange = geometry.drawRange;
+        const startPoint = drawRange.start;
+        const endPoint = Math.min(drawRange.start + drawRange.count, positions.count);
+
         const selected = [];
-        for (let i = 0; i < numPoints; i++) {
+        // Only check points within the draw range
+        for (let i = startPoint; i < endPoint; i++) {
             const x = positions.getX(i);
             const y = positions.getY(i);
             const z = positions.getZ(i);

--- a/src/lib/SpherePointSelector.ts
+++ b/src/lib/SpherePointSelector.ts
@@ -178,15 +178,20 @@ export class SpherePointSelector {
         const center = this.cursor.position;
         const geometry = this.points.geometry;
 
-        // Check if geometry has a valid 'position' attribute (not the case in the beginning of the app, when the eventListerer of the cursor already call this function)
+        // Check if geometry has a valid 'position' attribute
         if (!geometry || !geometry.getAttribute("position") || geometry.getAttribute("position").count === 0) {
             return [];
         }
 
         const positions = geometry.getAttribute("position");
-        const numPoints = positions.count;
+        // Get the draw range which indicates which points are actually active
+        const drawRange = geometry.drawRange;
+        const startPoint = drawRange.start;
+        const endPoint = Math.min(drawRange.start + drawRange.count, positions.count);
+
         const selected = [];
-        for (let i = 0; i < numPoints; i++) {
+        // Only check points within the draw range
+        for (let i = startPoint; i < endPoint; i++) {
             const x = positions.getX(i);
             const y = positions.getY(i);
             const z = positions.getZ(i);


### PR DESCRIPTION
When selecting a single cell with the sphere selector, sometimes a lot of "ghost" cells are selected (at least the app thinks this, they are not displayed). 

ToDo:
- [x] lots of ghost cells are located at the origin `(0,0,0)`
- [x] change default dataset back to zebrafish