### PR TITLE
Refresh selected/count labels

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -126,7 +126,7 @@ export default function App() {
                     // adding the track *in* the dispatcher creates issues with duplicate fetching
                     // but we refresh so the selected/loaded count is updated
                     canvas.addTrack(relatedTrackId, pos, ids, trackData[index]);
-                    // dispatchCanvas({ type: ActionType.REFRESH });
+                    dispatchCanvas({ type: ActionType.REFRESH });
                 });
             });
             setNumLoadingTracks((n) => n - 1);


### PR DESCRIPTION
call refresh after updating tracks to make sure selected/loaded count labels are updated