### PR TITLE
Fix arrow keys moving the canvas

### DIFF
--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -171,13 +171,6 @@ export class PointCanvas {
         // Set up controls
         this.controls = new OrbitControls(this.camera, this.renderer.domElement);
         this.controls.autoRotateSpeed = 1;
-        this.controls.listenToKeyEvents(window); // Enable keyboard controls
-        this.controls.keys = {
-            LEFT: "ArrowLeft",
-            UP: "ArrowUp",
-            RIGHT: "ArrowRight",
-            BOTTOM: "ArrowDown",
-        };
 
         // Set up selection
         this.selector = new PointSelector(this.scene, this.renderer, this.camera, this.controls, this.points);


### PR DESCRIPTION
removed wrong keyboard lines in `PointCanvas`, added when allowing tablet+keyboard