### PR TITLE
WIP - restructure conversion script regarding attribute types

### DIFF
--- a/.github/workflows/python-lint-and-test.yml
+++ b/.github/workflows/python-lint-and-test.yml
@@ -44,6 +44,11 @@ jobs:
         env:
           PLATFORM: ubuntu-latest
           BACKEND: pyqt5
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
   
   deploy:
     # this will run when you have tagged a commit, starting with "v*"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Tests](https://github.com/royerlab/inTRACKtive/actions/workflows/python-lint-and-test.yml/badge.svg)
+[![codecov](https://codecov.io/gh/royerlab/inTRACKtive/branch/main/graph/badge.svg)](https://codecov.io/gh/royerlab/inTRACKtive)
 [![PyPI version](https://badge.fury.io/py/intracktive.svg?cache_bust=1)](https://badge.fury.io/py/intracktive)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Contributors](https://img.shields.io/github/contributors-anon/royerlab/inTRACKtive)](https://github.com/royerlab/inTRACKtive/graphs/contributors)

--- a/python/src/intracktive/_tests/test_cli.py
+++ b/python/src/intracktive/_tests/test_cli.py
@@ -50,6 +50,46 @@ def test_convert_cli_single_attribute(
         ]
     )
 
+def test_convert_cli_single_hex_attribute(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    df.to_csv(tmp_path / "sample_data.csv", index=False)
+
+    _run_command(
+        [
+            "convert",
+            "--input_file",
+            str(tmp_path / "sample_data.csv"),
+            "--out_dir",
+            str(tmp_path),
+            "--add_hex_attribute",
+            "z",
+        ]
+    )
+
+def test_convert_cli_two_types_of_attributes(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    df.to_csv(tmp_path / "sample_data.csv", index=False)
+
+    _run_command(
+        [
+            "convert",
+            "--input_file",
+            str(tmp_path / "sample_data.csv"),
+            "--out_dir",
+            str(tmp_path),
+            "--add_hex_attribute",
+            "z,y",
+            "--add_attribute",
+            "x",
+        ]
+    )
+
 
 def test_convert_cli_multiple_attributes(
     tmp_path: Path,

--- a/python/src/intracktive/_tests/test_cli.py
+++ b/python/src/intracktive/_tests/test_cli.py
@@ -31,6 +31,22 @@ def test_convert_cli_simple(
     )
 
 
+def test_convert_cli_without_output_path(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    df.to_csv(tmp_path / "sample_data.csv", index=False)
+
+    _run_command(
+        [
+            "convert",
+            "--input_file",
+            str(tmp_path / "sample_data.csv"),
+        ]
+    )
+
+
 def test_convert_cli_single_attribute(
     tmp_path: Path,
     make_sample_data: pd.DataFrame,
@@ -50,6 +66,7 @@ def test_convert_cli_single_attribute(
         ]
     )
 
+
 def test_convert_cli_single_hex_attribute(
     tmp_path: Path,
     make_sample_data: pd.DataFrame,
@@ -68,6 +85,7 @@ def test_convert_cli_single_hex_attribute(
             "z",
         ]
     )
+
 
 def test_convert_cli_two_types_of_attributes(
     tmp_path: Path,
@@ -128,6 +146,27 @@ def test_convert_cli_all_attributes(
             "--add_all_attributes",
         ]
     )
+
+
+def test_convert_cli_missing_attributes(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    df.to_csv(tmp_path / "sample_data.csv", index=False)
+
+    with pytest.raises(ValueError):
+        _run_command(
+            [
+                "convert",
+                "--input_file",
+                str(tmp_path / "sample_data.csv"),
+                "--out_dir",
+                str(tmp_path),
+                "--add_attribute",
+                "nonexisting_column_name",
+            ]
+        )
 
 
 def test_convert_cli_all_attributes_prenormalized(

--- a/python/src/intracktive/_tests/test_convert.py
+++ b/python/src/intracktive/_tests/test_convert.py
@@ -51,6 +51,48 @@ def test_actual_zarr_content(tmp_path: Path, make_sample_data: pd.DataFrame) -> 
     _evaluate(new_data, gt_data)
 
 
+def test_convert_with_attributes_without_types(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+
+    new_path = tmp_path / "sample_data_bundle.zarr"
+    convert_dataframe_to_zarr(
+        df=df,
+        zarr_path=new_path,
+        extra_cols=['x','y'],
+    )
+
+def test_convert_with_attributes_with_types(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+
+    new_path = tmp_path / "sample_data_bundle.zarr"
+    convert_dataframe_to_zarr(
+        df=df,
+        zarr_path=new_path,
+        extra_cols=['x','y'],
+        attribute_types=['continuous','continuous'],
+    )
+
+def test_convert_with_attributes_with_wrong_number_of_types(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+
+    new_path = tmp_path / "sample_data_bundle.zarr"
+    convert_dataframe_to_zarr(
+        df=df,
+        zarr_path=new_path,
+        extra_cols=['x','y'],
+        attribute_types=['hex','continuous','categorical'],
+    )
+
+
 def test_convert_with_missing_column(
     tmp_path: Path,
     make_sample_data: pd.DataFrame,

--- a/python/src/intracktive/_tests/test_convert.py
+++ b/python/src/intracktive/_tests/test_convert.py
@@ -6,10 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import zarr
-from intracktive.convert import (
-    convert_dataframe_to_zarr,
-    dataframe_to_browser,
-)
+from intracktive.convert import convert_dataframe_to_zarr, dataframe_to_browser
 
 
 def _evaluate(new_group: zarr.Group, old_group: zarr.Group) -> None:

--- a/python/src/intracktive/_tests/test_convert.py
+++ b/python/src/intracktive/_tests/test_convert.py
@@ -1,10 +1,15 @@
+import webbrowser
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pytest
 import zarr
-from intracktive.convert import convert_dataframe_to_zarr
+from intracktive.convert import (
+    convert_dataframe_to_zarr,
+    dataframe_to_browser,
+)
 
 
 def _evaluate(new_group: zarr.Group, old_group: zarr.Group) -> None:
@@ -51,6 +56,54 @@ def test_actual_zarr_content(tmp_path: Path, make_sample_data: pd.DataFrame) -> 
     _evaluate(new_data, gt_data)
 
 
+def test_convert_if_zarr_file_exists(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    new_path = tmp_path / "sample_data_bundle.zarr"
+    convert_dataframe_to_zarr(
+        df=df,
+        zarr_path=new_path,
+        extra_cols=(),
+    )
+    convert_dataframe_to_zarr(
+        df=df,
+        zarr_path=new_path,
+        extra_cols=(),
+    )
+
+
+def test_dataframe_to_browser_with_attributes(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+
+    with patch.object(webbrowser, "open", return_value=True) as mock_browser:
+        try:
+            dataframe_to_browser(
+                df,
+                tmp_path,
+                extra_cols=["x", "y"],
+                attribute_types=["hex", "continuous"],
+            )
+            mock_browser.assert_called_once()
+        except Exception as e:
+            pytest.fail(f"Button click failed with error: {e}")
+
+
+def test_dataframe_to_browser_with_missing_attributes(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    df = df.drop(columns=["x", "y"])
+
+    with pytest.raises(ValueError):
+        dataframe_to_browser(df, tmp_path, extra_cols=["random_column"])
+
+
 def test_convert_with_attributes_without_types(
     tmp_path: Path,
     make_sample_data: pd.DataFrame,
@@ -61,8 +114,9 @@ def test_convert_with_attributes_without_types(
     convert_dataframe_to_zarr(
         df=df,
         zarr_path=new_path,
-        extra_cols=['x','y'],
+        extra_cols=["x", "y"],
     )
+
 
 def test_convert_with_attributes_with_types(
     tmp_path: Path,
@@ -74,9 +128,10 @@ def test_convert_with_attributes_with_types(
     convert_dataframe_to_zarr(
         df=df,
         zarr_path=new_path,
-        extra_cols=['x','y'],
-        attribute_types=['continuous','continuous'],
+        extra_cols=["x", "y"],
+        attribute_types=["continuous", "continuous"],
     )
+
 
 def test_convert_with_attributes_with_wrong_number_of_types(
     tmp_path: Path,
@@ -88,8 +143,8 @@ def test_convert_with_attributes_with_wrong_number_of_types(
     convert_dataframe_to_zarr(
         df=df,
         zarr_path=new_path,
-        extra_cols=['x','y'],
-        attribute_types=['hex','continuous','categorical'],
+        extra_cols=["x", "y"],
+        attribute_types=["hex", "continuous", "categorical"],
     )
 
 
@@ -239,4 +294,53 @@ def test_convert_with_invalid_velocity_window(
         zarr_path=new_path,
         calc_velocity=False,
         velocity_smoothing_windowsize=0,  # Should not raise error when calc_velocity is False
+    )
+
+
+def test_convert_with_continuous_attribute(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df1 = make_sample_data
+    df2 = make_sample_data.copy()
+    df3 = make_sample_data.copy()
+
+    # Modify x values to ensure uniqueness
+    df2["x"] = df2["x"] + 5
+    df3["x"] = df3["x"] + 10
+
+    # Concatenate the dataframes to get 15 unique values in x (to be detected as continuous attribute)
+    df = pd.concat([df1, df2, df3], ignore_index=True)
+
+    new_path = tmp_path / "sample_data_bundle.zarr"
+    convert_dataframe_to_zarr(
+        df=df,
+        zarr_path=new_path,
+        extra_cols=["x"],
+    )
+
+
+def test_convert_with_parents_and_children(
+    tmp_path: Path,
+    make_sample_data: pd.DataFrame,
+) -> None:
+    df = make_sample_data
+    new_rows = pd.DataFrame(
+        [
+            [5, 2, 50, 50, 50, 4],  # track 5 is child of 4
+            [6, 2, 60, 60, 60, 5],  # track 6 is child of 5
+            [7, 3, 70, 70, 70, 6],  # track 7 is child of 6
+            [8, 3, 80, 80, 80, 7],  # track 8 is child of 7
+        ],
+        columns=["track_id", "t", "z", "y", "x", "parent_track_id"],
+    )
+
+    df = pd.concat([df, new_rows], ignore_index=True)
+
+    # Create a new column with parent-child relationships
+
+    new_path = tmp_path / "sample_data_bundle.zarr"
+    convert_dataframe_to_zarr(
+        df=df,
+        zarr_path=new_path,
     )

--- a/python/src/intracktive/convert.py
+++ b/python/src/intracktive/convert.py
@@ -687,7 +687,7 @@ def convert_cli(
             extra_cols = extra_cols + selected_columns
             for c in selected_columns:
                 col_types.append("hex")
-            print(f"Columns included as attributes: {', '.join(selected_columns)}")
+            print(f"Columns included as hex attributes: {', '.join(selected_columns)}")
     print(f"Column types: {col_types}")
 
     convert_dataframe_to_zarr(

--- a/python/src/intracktive/convert.py
+++ b/python/src/intracktive/convert.py
@@ -46,6 +46,8 @@ def _transitive_closure(
     start = time.monotonic()
 
     iter = 0
+    print("graph.nnz", graph.nnz)
+    print("graph**2.nnz", (graph**2).nnz)
     while graph.nnz != (nxt := graph**2).nnz:
         graph = nxt
         iter += 1
@@ -492,7 +494,7 @@ def dataframe_to_browser(
             zarr_dir = Path(temp_dir)
             LOG.info("Temporary directory used for localhost: %s", zarr_dir)
     else:
-        LOG.info("Provided directory used used for localhost: %s", zarr_dir)
+        LOG.info("Provided directory used for localhost: %s", zarr_dir)
 
     # check if extra_cols are in df
     for col in extra_cols:
@@ -519,7 +521,6 @@ def dataframe_to_browser(
 
     LOG.info("localhost successfully launched, serving: %s", zarr_dir_with_storename)
 
-    baseUrl = "https://intracktive.sf.czbiohub.org"  # inTRACKtive application
     dataUrl = (
         hostURL + "/" + zarr_path.name + "/"
     )  # exact path of the data (on localhost)
@@ -693,7 +694,9 @@ def convert_cli(
             extra_cols = extra_cols + selected_columns
             for c in selected_columns:
                 col_types.append("hex")
-            LOG.info(f"Columns included as hex attributes: {', '.join(selected_columns)}")
+            LOG.info(
+                f"Columns included as hex attributes: {', '.join(selected_columns)}"
+            )
     LOG.info(f"Column types: {col_types}")
 
     convert_dataframe_to_zarr(

--- a/python/src/intracktive/convert.py
+++ b/python/src/intracktive/convert.py
@@ -462,6 +462,7 @@ def dataframe_to_browser(
     zarr_dir: Path,
     extra_cols: Iterable[str] = (),
     attribute_types: Iterable[str] = (),
+    add_radius: bool = False,
 ) -> None:
     """
     Open a Tracks DataFrame in inTRACKtive in the browser. In detail: this function
@@ -476,6 +477,8 @@ def dataframe_to_browser(
         The directory to save the Zarr bundle, only the path to the folder is required (excluding the zarr_bundle.zarr filename)
     extra_cols : Iterable[str], optional
         List of extra columns to include in the Zarr store, by default empty list
+    add_radius: bool, optional
+            Boolean indicating whether to include the column radius as cell size, by default False
     """
 
     if str(zarr_dir) in (".", None):
@@ -499,6 +502,7 @@ def dataframe_to_browser(
         df=df,
         zarr_path=zarr_path,
         extra_cols=extra_cols,
+        add_radius=add_radius,
         attribute_types=attribute_types,
     )
 
@@ -676,14 +680,14 @@ def convert_cli(
             extra_cols = selected_columns
             for c in selected_columns:
                 col_types.append(get_col_type(tracks_df[c]))
-
+            print(f"Columns included as attributes: {', '.join(selected_columns)}")
         if add_hex_attribute:
             selected_columns = [col.strip() for col in add_hex_attribute.split(",")]
             check_if_columns_exist(selected_columns, tracks_df.columns)
             extra_cols = extra_cols + selected_columns
             for c in selected_columns:
                 col_types.append("hex")
-    print(f"Columns included as attributes: {', '.join(selected_columns)}")
+            print(f"Columns included as attributes: {', '.join(selected_columns)}")
     print(f"Column types: {col_types}")
 
     convert_dataframe_to_zarr(

--- a/python/src/intracktive/convert.py
+++ b/python/src/intracktive/convert.py
@@ -46,8 +46,6 @@ def _transitive_closure(
     start = time.monotonic()
 
     iter = 0
-    print("graph.nnz", graph.nnz)
-    print("graph**2.nnz", (graph**2).nnz)
     while graph.nnz != (nxt := graph**2).nnz:
         graph = nxt
         iter += 1
@@ -520,11 +518,11 @@ def dataframe_to_browser(
     )
 
     LOG.info("localhost successfully launched, serving: %s", zarr_dir_with_storename)
-
+    baseUrl = "https://intracktive.sf.czbiohub.org"  # inTRACKtive application
     dataUrl = (
         hostURL + "/" + zarr_path.name + "/"
     )  # exact path of the data (on localhost)
-    fullUrl = generate_viewer_state_hash(
+    fullUrl = baseUrl + generate_viewer_state_hash(
         data_url=str(dataUrl)
     )  # full hash that encodes viewerState
     LOG.info("Copy the following URL into the Google Chrome browser:")


### PR DESCRIPTION
Changes: 
- added attribute types to conversion scripts (bot `_to_zarr` and `_to_browser`), mainly to allow hexInt attributes
- fixed bug that browser opened wrong `zarr_bundle`, when `get_unique_zarr_path` incremented the number

ToDo = testing:
- [x] revisit test script to see if all edge cases are covered
- [x] input various column types (regular, hex, regular+hex, all)
- [x] conversion with/without provided column types
- [x] check test coverage
- [x] test all on `df_to_zarr` and `df_to_browser`