### PR TITLE
select subgroup of cells

### DIFF
--- a/CONFIG.ts
+++ b/CONFIG.ts
@@ -11,8 +11,7 @@ const config = {
     // When opening the viewer, or refreshing the page, the viewer will revert to the following default dataset
     data:{
         // Default dataset URL (must be publically accessible)
-        // default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
-        default_dataset: "https://onsite.czbiohub.org/royerlab/inTRACKtive/ChromaTrace/2024_08_14/2024_08_14_zarr_bundle.zarr/"
+        default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
     },
   
     // Default settings for certain parameters

--- a/CONFIG.ts
+++ b/CONFIG.ts
@@ -11,7 +11,8 @@ const config = {
     // When opening the viewer, or refreshing the page, the viewer will revert to the following default dataset
     data:{
         // Default dataset URL (must be publically accessible)
-        default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
+        // default_dataset: "https://public.czbiohub.org/royerlab/zoo/Zebrafish/tracks_zebrafish_bundle.zarr/"
+        default_dataset: "https://onsite.czbiohub.org/royerlab/inTRACKtive/ChromaTrace/2024_08_14/2024_08_14_zarr_bundle.zarr/"
     },
   
     // Default settings for certain parameters

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -379,10 +379,10 @@ export default function App() {
                                 selectorScale={canvas.selector.sphereSelector.cursor.scale.x}
                                 colorBy={canvas.colorBy}
                                 colorByEvent={canvas.colorByEvent}
-                                onSelectBinaryValue={(indices: number[], pointIds: Set<number>) => {
+                                onSelectBinaryValue={(pointIds: Set<number>) => {
                                     dispatchCanvas({
                                         type: ActionType.ADD_SELECTED_POINT_IDS,
-                                        selectedPointIndices: indices,
+                                        selectedPointIndices: [],
                                         selectedPointIds: pointIds,
                                     });
                                 }}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -275,52 +275,36 @@ export default function App() {
 
     const getTrackDownloadData = () => {
         const trackData: TrackDownloadData[] = [];
-        canvas.tracks.forEach((track, trackID) => {
-            // Keep track of the timepoints we've seen in this track to avoid duplication
-            // This is necessary because if a track contains a single point, we set
-            // the start and end positions to be the same
-            const timepointsInTrack = new Set();
+        // For each selected point ID
+        canvas.selectedPointIds.forEach((pointId) => {
+            // Calculate time and index from pointId
+            const time = Math.floor(pointId / canvas.maxPointsPerTimepoint);
 
-            const startPositions = track.threeTrack.geometry.getAttribute("instanceStart");
-            const startTimes = track.threeTrack.geometry.getAttribute("instanceTimeStart");
+            // Find which track contains this point
+            canvas.tracks.forEach((track, trackID) => {
+                // Check if this point is in this track
+                const pointIndex = track.threeTrack.pointIds.indexOf(pointId);
+                if (pointIndex !== -1) {
+                    // Get position data for this specific point
+                    const positions = track.threeTrack.geometry.getAttribute("instanceStart");
 
-            for (let i = 0; i < startTimes.count; i++) {
-                timepointsInTrack.add(startTimes.getX(i));
-                trackData.push([
-                    // trackID is 1-indexed in input and output CSVs
-                    trackID + 1,
-                    startTimes.getX(i),
-                    startPositions.getX(i),
-                    startPositions.getY(i),
-                    startPositions.getZ(i),
-                    track.parentTrackID,
-                ]);
-            }
-            const endPositions = track.threeTrack.geometry.getAttribute("instanceEnd");
-            const endTimes = track.threeTrack.geometry.getAttribute("instanceTimeEnd");
-            const lastIndex = endPositions.count - 1;
-
-            // Only add the end position if it's not the same as the start position
-            if (!timepointsInTrack.has(endTimes.getX(lastIndex))) {
-                trackData.push([
-                    // trackID is 1-indexed in input and output CSVs
-                    trackID + 1,
-                    endTimes.getX(lastIndex),
-                    endPositions.getX(lastIndex),
-                    endPositions.getY(lastIndex),
-                    endPositions.getZ(lastIndex),
-                    track.parentTrackID,
-                ]);
-            }
+                    // Add just this point to the export data
+                    trackData.push([
+                        // trackID is 1-indexed in input and output CSVs
+                        trackID + 1,
+                        time,
+                        positions.getX(pointIndex),
+                        positions.getY(pointIndex),
+                        positions.getZ(pointIndex),
+                        track.parentTrackID,
+                    ]);
+                }
+            });
         });
 
         // Sort the trackData by track ID (first column) and then by time (second column)
         trackData.sort((a, b) => {
-            // First compare by trackID (a[0], b[0])
-            if (a[0] !== b[0]) {
-                return a[0] - b[0];
-            }
-            // If trackID is the same, compare by time (a[1], b[1])
+            if (a[0] !== b[0]) return a[0] - b[0];
             return a[1] - b[1];
         });
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -393,6 +393,15 @@ export default function App() {
                                     dispatchCanvas({ type: ActionType.SELECTOR_SCALE, scale });
                                 }}
                                 selectorScale={canvas.selector.sphereSelector.cursor.scale.x}
+                                colorBy={canvas.colorBy}
+                                colorByEvent={canvas.colorByEvent}
+                                onSelectBinaryValue={(indices: number[], pointIds: Set<number>) => {
+                                    dispatchCanvas({
+                                        type: ActionType.ADD_SELECTED_POINT_IDS,
+                                        selectedPointIndices: indices,
+                                        selectedPointIds: pointIds,
+                                    });
+                                }}
                             />
                             <Divider sx={{ marginY: "1em" }} />
                             <LeftSidebarWrapper

--- a/src/components/CellControls.tsx
+++ b/src/components/CellControls.tsx
@@ -62,7 +62,6 @@ export default function CellControls(props: CellControlsProps) {
             }
 
             props.onSelectBinaryValue(selectedIds);
-
         } catch (error) {
             console.error("Error during binary selection:", error);
         }

--- a/src/components/CellControls.tsx
+++ b/src/components/CellControls.tsx
@@ -20,7 +20,7 @@ interface CellControlsProps {
     selectorScale: number;
     colorBy: boolean;
     colorByEvent: Option;
-    onSelectBinaryValue: (indices: number[], ids: Set<number>) => void;
+    onSelectBinaryValue: (ids: Set<number>) => void;
 }
 
 export default function CellControls(props: CellControlsProps) {
@@ -53,18 +53,16 @@ export default function CellControls(props: CellControlsProps) {
 
             const numPoints = points.length / 3;
 
-            // Process selection if under limit
-            const selectedIndices: number[] = [];
             const selectedIds = new Set<number>();
             for (let i = 0; i < numPoints && i < attributes.length; i++) {
                 if (attributes[i] === 16711680) {
-                    selectedIndices.push(i);
                     const pointId = props.trackManager.annotTime * props.trackManager.maxPointsPerTimepoint + i;
                     selectedIds.add(pointId);
                 }
             }
 
-            props.onSelectBinaryValue(selectedIndices, selectedIds);
+            props.onSelectBinaryValue(selectedIds);
+
         } catch (error) {
             console.error("Error during binary selection:", error);
         }

--- a/src/components/CellControls.tsx
+++ b/src/components/CellControls.tsx
@@ -85,6 +85,16 @@ export default function CellControls(props: CellControlsProps) {
                 <strong>{props.numSelectedTracks ?? 0}</strong> tracks loaded
             </FontS>
             {!!props.numSelectedCells && <DownloadButton getDownloadData={props.getTrackDownloadData} />}
+
+            {props.trackManager &&
+                props.colorBy &&
+                props.colorByEvent.type === "hex-binary" &&
+                (props.numSelectedCells ?? 0) == 0 && (
+                    <Button sdsStyle="square" sdsType="primary" onClick={handleBinarySelection}>
+                        Load tracks for annotated cells
+                    </Button>
+                )}
+
             {/* Selection mode buttons */}
             <label htmlFor="selection-mode-control">
                 <ControlLabel>Selection Mode</ControlLabel>

--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -426,7 +426,8 @@ export class PointCanvas {
                 if (
                     this.colorByEvent.action != "provided-normalized" &&
                     attributes.length > 0 &&
-                    this.colorByEvent.type != "hex"
+                    this.colorByEvent.type != "hex" &&
+                    this.colorByEvent.type != "hex-binary"
                 ) {
                     attributes = this.normalizeAttributeVector(attributes);
                 }
@@ -443,7 +444,7 @@ export class PointCanvas {
             for (let i = 0; i < numPoints; i++) {
                 colorAttribute.setXYZ(i, color.r, color.g, color.b);
             }
-        } else if (this.colorByEvent.type === "hex") {
+        } else if (this.colorByEvent.type === "hex" || this.colorByEvent.type === "hex-binary") {
             for (let i = 0; i < numPoints; i++) {
                 const hexInt = attributes[i]; // must be [0 1]
                 if (hexInt === undefined) {

--- a/src/lib/TrackManager.ts
+++ b/src/lib/TrackManager.ts
@@ -369,7 +369,7 @@ export async function loadTrackManager(url: string) {
             console.debug("attribute types found: %s", zattrs["attribute_types"]);
 
             annotTime = zattrs["annot_time"] ?? 0;
-            console.log("annotTime:", annotTime);
+            console.debug("annotTime:", annotTime);
             for (let column = 0; column < zattrs["attribute_names"].length; column++) {
                 addDropDownOption(attributeOptions, {
                     name: zattrs["attribute_names"][column],

--- a/src/lib/TrackManager.ts
+++ b/src/lib/TrackManager.ts
@@ -13,7 +13,7 @@ const showDefaultAttributes = config.settings.showDefaultAttributes;
 export type Option = {
     name: string;
     label: number;
-    type: "default" | "categorical" | "continuous" | "hex";
+    type: "default" | "categorical" | "continuous" | "hex" | "hex-binary";
     action: "default" | "calculate" | "provided" | "provided-normalized";
     numCategorical: number | undefined;
 };
@@ -177,6 +177,7 @@ export class TrackManager {
     scaleSettings: ScaleSettings;
     defaultExtent: number;
     ndim: number;
+    annotTime: number;
 
     constructor(
         store: string,
@@ -187,6 +188,7 @@ export class TrackManager {
         attributes: ZarrArray,
         attributeOptions: Option[],
         scaleSettings: ScaleSettings,
+        annotTime: number,
     ) {
         this.store = store;
         this.points = points;
@@ -196,10 +198,11 @@ export class TrackManager {
         this.attributes = attributes;
         this.attributeOptions = attributeOptions;
         this.numTimes = points.shape[0];
-        this.maxPointsPerTimepoint = points.shape[1] / numberOfValuesPerPoint; // default is /3
+        this.maxPointsPerTimepoint = points.shape[1] / numberOfValuesPerPoint;
         this.scaleSettings = scaleSettings;
         this.defaultExtent = 1; // pointcloud is centered around (0,0,0) with an extent of 1
         this.ndim = 3;
+        this.annotTime = annotTime;
     }
 
     async fetchPointsAtTime(timeIndex: number): Promise<Float32Array> {
@@ -353,6 +356,7 @@ export async function loadTrackManager(url: string) {
         const tracksToTracks = await openSparseZarrArray(url, "tracks_to_tracks", true);
 
         let attributes = null;
+        let annotTime = 0;
         let attributeOptions: Option[] = resetDropDownOptions();
         try {
             attributes = await openArray({
@@ -364,6 +368,8 @@ export async function loadTrackManager(url: string) {
             console.debug("attribute names found: %s", zattrs["attribute_names"]);
             console.debug("attribute types found: %s", zattrs["attribute_types"]);
 
+            annotTime = zattrs["annot_time"] ?? 0;
+            console.log("annotTime:", annotTime);
             for (let column = 0; column < zattrs["attribute_names"].length; column++) {
                 addDropDownOption(attributeOptions, {
                     name: zattrs["attribute_names"][column],
@@ -389,6 +395,7 @@ export async function loadTrackManager(url: string) {
             attributes,
             attributeOptions,
             scaleSettings,
+            annotTime,
         );
         if (numberOfValuesPerPoint == 4) {
             trackManager.maxPointsPerTimepoint = trackManager.points.shape[1] / numberOfValuesPerPoint;


### PR DESCRIPTION
Compared to Main, this branch: 

- the `Export Cell Tracks` button only export the selected cells. Not all cells of the tracks, of all related tracks

ToDo: 
- [x] solve pink-cell issue if button is pressed in different time frame than annot_time
- [ ] add `hex-binary` to TO script when creating the zarr
- [x] config back to normal
- [x] solve warning error when selecting more than 100 cells
- [x] change name of button

Notes:
- `annot_time` not in zattrs automatically (do this manually)