### PR TITLE
Add RGB coloring for multiple continuous attributes

### DIFF
--- a/__tests__/attributeColors.test.ts
+++ b/__tests__/attributeColors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import { composeRgbAttributes, selectRgbAttributes } from "../src/lib/AttributeColors";
+
+describe("selectRgbAttributes", () => {
+    test("keeps unique continuous features in user selection order and limits them to three", () => {
+        const selected = selectRgbAttributes([
+            { label: 4, type: "categorical", name: "ignored" },
+            { label: 8, type: "continuous", name: "red" },
+            { label: 7, type: "continuous", name: "green" },
+            { label: 8, type: "continuous", name: "duplicate" },
+            { label: 9, type: "continuous", name: "blue" },
+            { label: 10, type: "continuous", name: "too many" },
+        ]);
+
+        expect(selected.map((option) => option.name)).toEqual(["red", "green", "blue"]);
+    });
+});
+
+describe("composeRgbAttributes", () => {
+    test("assigns features to red, green, and blue in selection order", () => {
+        const colors = composeRgbAttributes(
+            [new Float32Array([0, 10]), new Float32Array([4, 2]), new Float32Array([7, 7])],
+            [false, false, false],
+            2,
+            1,
+        );
+
+        expect(Array.from(colors)).toEqual([0, 1, 1, 1, 0, 1]);
+    });
+
+    test("keeps missing channels at zero and applies brightness", () => {
+        const colors = composeRgbAttributes([new Float32Array([0.25, 1])], [true], 2, 0.5);
+
+        expect(Array.from(colors)).toEqual([0.125, 0, 0, 0.5, 0, 0]);
+    });
+
+    test("clamps pre-normalized values and treats non-finite values as zero", () => {
+        const colors = composeRgbAttributes(
+            [new Float32Array([-1, 2, Number.NaN]), new Float32Array([0, 0.5, 1])],
+            [true, true],
+            3,
+            1,
+        );
+
+        expect(Array.from(colors)).toEqual([0, 0, 0, 1, 0.5, 0, 0, 1, 0]);
+    });
+
+    test("uses at most three attributes", () => {
+        const colors = composeRgbAttributes(
+            [new Float32Array([1]), new Float32Array([1]), new Float32Array([1]), new Float32Array([0])],
+            [true, true, true, true],
+            1,
+            1,
+        );
+
+        expect(Array.from(colors)).toEqual([1, 1, 1]);
+    });
+});

--- a/__tests__/attributeColors.test.ts
+++ b/__tests__/attributeColors.test.ts
@@ -1,24 +1,34 @@
 import { describe, expect, test } from "vitest";
 
-import { composeRgbAttributes, selectRgbAttributes } from "../src/lib/AttributeColors";
+import { composeRgbAttributes, RGB_BACKGROUND, selectRgbAttributes } from "../src/lib/AttributeColors";
+
+const expectColors = (colors: Float32Array, expected: number[]) => {
+    expect(colors).toHaveLength(expected.length);
+    expected.forEach((value, index) => expect(colors[index]).toBeCloseTo(value));
+};
 
 describe("selectRgbAttributes", () => {
-    test("keeps unique continuous features in user selection order and limits them to three", () => {
+    test("preserves channel slots while rejecting invalid and duplicate features", () => {
+        const red = { label: 8, type: "continuous", name: "red" };
         const selected = selectRgbAttributes([
+            red,
+            null,
+            { label: 7, type: "continuous", name: "blue" },
+            { label: 9, type: "continuous", name: "too many" },
+        ]);
+        const invalid = selectRgbAttributes([
+            red,
             { label: 4, type: "categorical", name: "ignored" },
-            { label: 8, type: "continuous", name: "red" },
-            { label: 7, type: "continuous", name: "green" },
-            { label: 8, type: "continuous", name: "duplicate" },
-            { label: 9, type: "continuous", name: "blue" },
-            { label: 10, type: "continuous", name: "too many" },
+            { ...red, name: "duplicate" },
         ]);
 
-        expect(selected.map((option) => option.name)).toEqual(["red", "green", "blue"]);
+        expect(selected.map((option) => option?.name ?? null)).toEqual(["red", null, "blue"]);
+        expect(invalid).toEqual([red, null, null]);
     });
 });
 
 describe("composeRgbAttributes", () => {
-    test("assigns features to red, green, and blue in selection order", () => {
+    test("assigns features to red, green, and blue in channel order", () => {
         const colors = composeRgbAttributes(
             [new Float32Array([0, 10]), new Float32Array([4, 2]), new Float32Array([7, 7])],
             [false, false, false],
@@ -26,16 +36,22 @@ describe("composeRgbAttributes", () => {
             1,
         );
 
-        expect(Array.from(colors)).toEqual([0, 1, 1, 1, 0, 1]);
+        expectColors(colors, [RGB_BACKGROUND, 1, 1, 1, RGB_BACKGROUND, 1]);
     });
 
-    test("keeps missing channels at zero and applies brightness", () => {
+    test("keeps missing channels dim gray and applies brightness", () => {
         const colors = composeRgbAttributes([new Float32Array([0.25, 1])], [true], 2, 0.5);
 
-        expect(Array.from(colors)).toEqual([0.125, 0, 0, 0.5, 0, 0]);
+        expectColors(colors, [0.125, RGB_BACKGROUND * 0.5, RGB_BACKGROUND * 0.5, 0.5, 0.04, 0.04]);
     });
 
-    test("clamps pre-normalized values and treats non-finite values as zero", () => {
+    test("shows cells as dim gray even when no feature has color", () => {
+        const colors = composeRgbAttributes([], [], 2, 1);
+
+        expectColors(colors, new Array(6).fill(RGB_BACKGROUND));
+    });
+
+    test("clamps pre-normalized values and treats non-finite values as gray", () => {
         const colors = composeRgbAttributes(
             [new Float32Array([-1, 2, Number.NaN]), new Float32Array([0, 0.5, 1])],
             [true, true],
@@ -43,7 +59,7 @@ describe("composeRgbAttributes", () => {
             1,
         );
 
-        expect(Array.from(colors)).toEqual([0, 0, 0, 1, 0.5, 0, 0, 1, 0]);
+        expectColors(colors, [0.08, 0.08, 0.08, 1, 0.5, 0.08, 0.08, 1, 0.08]);
     });
 
     test("uses at most three attributes", () => {
@@ -54,6 +70,6 @@ describe("composeRgbAttributes", () => {
             1,
         );
 
-        expect(Array.from(colors)).toEqual([1, 1, 1]);
+        expectColors(colors, [1, 1, 1]);
     });
 });

--- a/__tests__/rgbFeatureSelect.test.tsx
+++ b/__tests__/rgbFeatureSelect.test.tsx
@@ -26,11 +26,23 @@ describe("RgbFeatureSelect", () => {
             </>,
         );
 
-        expect(screen.getByLabelText("Red feature")).toBeTruthy();
-        expect(screen.getByLabelText("Green feature")).toBeTruthy();
-        expect(screen.getByLabelText("Blue feature")).toBeTruthy();
+        const redInput = screen.getByLabelText("Red feature");
+        const greenInput = screen.getByLabelText("Green feature");
+        const blueInput = screen.getByLabelText("Blue feature");
+        expect(redInput).toBeTruthy();
+        expect(greenInput).toBeTruthy();
+        expect(blueInput).toBeTruthy();
+        expect(getComputedStyle(redInput.closest(".MuiAutocomplete-root")!).backgroundColor).toBe(
+            "rgba(255, 80, 80, 0.12)",
+        );
+        expect(getComputedStyle(greenInput.closest(".MuiAutocomplete-root")!).backgroundColor).toBe(
+            "rgba(60, 180, 90, 0.12)",
+        );
+        expect(getComputedStyle(blueInput.closest(".MuiAutocomplete-root")!).backgroundColor).toBe(
+            "rgba(70, 130, 255, 0.12)",
+        );
 
-        fireEvent.change(screen.getByLabelText("Red feature"), { target: { value: "gata" } });
+        fireEvent.change(redInput, { target: { value: "gata" } });
         fireEvent.click(screen.getByRole("option", { name: "gata1a" }));
 
         expect(onRedChange).toHaveBeenCalledWith(options[0]);

--- a/__tests__/rgbFeatureSelect.test.tsx
+++ b/__tests__/rgbFeatureSelect.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { RgbFeatureSelect } from "../src/components/leftSidebar/TrackControls";
+import { Option } from "../src/lib/TrackManager";
+
+const feature = (name: string, label: number): Option => ({
+    name,
+    label,
+    type: "continuous",
+    action: "provided-normalized",
+    numCategorical: undefined,
+});
+
+describe("RgbFeatureSelect", () => {
+    test("provides an independent searchable input for each color channel", () => {
+        const options = [feature("gata1a", 6), feature("foxd3", 7)];
+        const onRedChange = vi.fn();
+
+        render(
+            <>
+                <RgbFeatureSelect channel="Red" options={options} value={null} onChange={onRedChange} />
+                <RgbFeatureSelect channel="Green" options={options} value={null} onChange={vi.fn()} />
+                <RgbFeatureSelect channel="Blue" options={options} value={null} onChange={vi.fn()} />
+            </>,
+        );
+
+        expect(screen.getByLabelText("Red feature")).toBeTruthy();
+        expect(screen.getByLabelText("Green feature")).toBeTruthy();
+        expect(screen.getByLabelText("Blue feature")).toBeTruthy();
+
+        fireEvent.change(screen.getByLabelText("Red feature"), { target: { value: "gata" } });
+        fireEvent.click(screen.getByRole("option", { name: "gata1a" }));
+
+        expect(onRedChange).toHaveBeenCalledWith(options[0]);
+    });
+});

--- a/__tests__/viewerState.test.ts
+++ b/__tests__/viewerState.test.ts
@@ -15,13 +15,13 @@ describe("ViewerState RGB features", () => {
     test("round-trips the ordered feature selection", () => {
         const state = new ViewerState();
         state.multiColorBy = true;
-        state.colorByEvents = [continuousOption("first", 6), continuousOption("second", 7)];
+        state.colorByEvents = [continuousOption("first", 6), null, continuousOption("third", 7)];
 
         const restored = ViewerState.fromUrlHash(state.toUrlHash());
 
         expect(restored).toBeInstanceOf(ViewerState);
         expect(restored.multiColorBy).toBe(true);
-        expect(restored.colorByEvents.map((option) => option.name)).toEqual(["first", "second"]);
+        expect(restored.colorByEvents.map((option) => option?.name ?? null)).toEqual(["first", null, "third"]);
     });
 
     test("supplies RGB defaults for links created before multi-color mode", () => {

--- a/__tests__/viewerState.test.ts
+++ b/__tests__/viewerState.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+
+import { Option } from "../src/lib/TrackManager";
+import { ViewerState } from "../src/lib/ViewerState";
+
+const continuousOption = (name: string, label: number): Option => ({
+    name,
+    label,
+    type: "continuous",
+    action: "provided",
+    numCategorical: undefined,
+});
+
+describe("ViewerState RGB features", () => {
+    test("round-trips the ordered feature selection", () => {
+        const state = new ViewerState();
+        state.multiColorBy = true;
+        state.colorByEvents = [continuousOption("first", 6), continuousOption("second", 7)];
+
+        const restored = ViewerState.fromUrlHash(state.toUrlHash());
+
+        expect(restored).toBeInstanceOf(ViewerState);
+        expect(restored.multiColorBy).toBe(true);
+        expect(restored.colorByEvents.map((option) => option.name)).toEqual(["first", "second"]);
+    });
+
+    test("supplies RGB defaults for links created before multi-color mode", () => {
+        const oldState = new URLSearchParams();
+        oldState.append("viewerState", JSON.stringify({ colorBy: true }));
+
+        const restored = ViewerState.fromUrlHash(`#${oldState.toString()}`);
+
+        expect(restored.multiColorBy).toBe(false);
+        expect(restored.colorByEvents).toEqual([]);
+    });
+});

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -218,7 +218,7 @@ export default function App() {
                 if (canvas.multiColorBy) {
                     multiAttributes = await Promise.all(
                         canvas.colorByEvents.map((option) =>
-                            option.action === "provided" || option.action === "provided-normalized"
+                            option?.action === "provided" || option?.action === "provided-normalized"
                                 ? trackManager.fetchAttributesAtTime(time, option.label - numberOfDefaultColorByOptions)
                                 : Promise.resolve(undefined),
                         ),
@@ -587,7 +587,7 @@ export default function App() {
                                     dispatchCanvas({ type: ActionType.TOGGLE_MULTI_COLOR_BY, enabled });
                                 }}
                                 colorByEvents={canvas.colorByEvents}
-                                changeMultiColorBy={(options: Option[]) => {
+                                changeMultiColorBy={(options: Array<Option | null>) => {
                                     dispatchCanvas({ type: ActionType.CHANGE_MULTI_COLOR_BY, options });
                                 }}
                                 colormapTracks={canvas.colormapTracks}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -213,18 +213,40 @@ export default function App() {
                     return;
                 }
 
-                let attributes;
-                if (canvas.colorByEvent.action === "provided" || canvas.colorByEvent.action === "provided-normalized") {
+                let attributes: Float32Array | undefined;
+                let multiAttributes: Array<Float32Array | undefined> | undefined;
+                if (canvas.multiColorBy) {
+                    multiAttributes = await Promise.all(
+                        canvas.colorByEvents.map((option) =>
+                            option.action === "provided" || option.action === "provided-normalized"
+                                ? trackManager.fetchAttributesAtTime(time, option.label - numberOfDefaultColorByOptions)
+                                : Promise.resolve(undefined),
+                        ),
+                    );
+                } else if (
+                    canvas.colorByEvent.action === "provided" ||
+                    canvas.colorByEvent.action === "provided-normalized"
+                ) {
                     attributes = await trackManager.fetchAttributesAtTime(
                         time,
                         canvas.colorByEvent.label - numberOfDefaultColorByOptions,
                     );
                 }
 
+                if (ignore) {
+                    console.debug("IGNORE SET points at time %d after fetching attributes", time);
+                    return;
+                }
+
                 // clearing the timeout prevents the loading indicator from showing at all if the fetch is fast
                 clearTimeout(loadingTimeout);
                 setIsLoadingPoints(false);
-                dispatchCanvas({ type: ActionType.POINTS_POSITIONS, positions: data, attributes });
+                dispatchCanvas({
+                    type: ActionType.POINTS_POSITIONS,
+                    positions: data,
+                    attributes,
+                    multiAttributes,
+                });
             };
             getPoints(canvas.curTime);
         } else {
@@ -242,7 +264,7 @@ export default function App() {
             clearTimeout(loadingTimeout);
             ignore = true;
         };
-    }, [canvas.curTime, canvas.colorByEvent, dispatchCanvas, trackManager]);
+    }, [canvas.curTime, canvas.colorByEvent, canvas.multiColorBy, canvas.colorByEvents, dispatchCanvas, trackManager]);
 
     // This fetches track IDs based on the selected point IDs.
     useEffect(() => {
@@ -560,6 +582,14 @@ export default function App() {
                                 changeColorBy={(option: Option) => {
                                     dispatchCanvas({ type: ActionType.CHANGE_COLOR_BY, option });
                                 }}
+                                multiColorBy={canvas.multiColorBy}
+                                toggleMultiColorBy={(enabled: boolean) => {
+                                    dispatchCanvas({ type: ActionType.TOGGLE_MULTI_COLOR_BY, enabled });
+                                }}
+                                colorByEvents={canvas.colorByEvents}
+                                changeMultiColorBy={(options: Option[]) => {
+                                    dispatchCanvas({ type: ActionType.CHANGE_MULTI_COLOR_BY, options });
+                                }}
                                 colormapTracks={canvas.colormapTracks}
                                 setColormapTracks={(colormapName: string) => {
                                     dispatchCanvas({ type: ActionType.CHANGE_COLORMAP_TRACKS, colormapName });
@@ -619,16 +649,18 @@ export default function App() {
                     <Scene isLoading={isLoadingPoints || numLoadingTracks > 0} />
                     {/* <TimestampOverlay timestamp={canvas.curTime} /> */}
                     {numSelectedCells > 0 && <ColorMapTracks colormapName={canvas.colormapTracks} />}
-                    {canvas.colorByEvent.type !== "default" && canvas.colorByEvent.type !== "hex" && (
-                        <ColorMapCells
-                            colorByEvent={canvas.colorByEvent}
-                            colormapName={
-                                canvas.colorByEvent.type === "categorical"
-                                    ? canvas.colormapCellsCategorical
-                                    : canvas.colormapCellsContinuous
-                            }
-                        />
-                    )}
+                    {!canvas.multiColorBy &&
+                        canvas.colorByEvent.type !== "default" &&
+                        canvas.colorByEvent.type !== "hex" && (
+                            <ColorMapCells
+                                colorByEvent={canvas.colorByEvent}
+                                colormapName={
+                                    canvas.colorByEvent.type === "categorical"
+                                        ? canvas.colormapCellsCategorical
+                                        : canvas.colormapCellsContinuous
+                                }
+                            />
+                        )}
                 </Box>
 
                 {/* The playback controls */}

--- a/src/components/leftSidebar/LeftSidebarWrapper.tsx
+++ b/src/components/leftSidebar/LeftSidebarWrapper.tsx
@@ -26,6 +26,10 @@ interface LeftSidebarWrapperProps {
     colorByEvent: Option;
     toggleColorBy: (colorBy: boolean) => void;
     changeColorBy: (value: Option) => void;
+    multiColorBy: boolean;
+    toggleMultiColorBy: (enabled: boolean) => void;
+    colorByEvents: Option[];
+    changeMultiColorBy: (values: Option[]) => void;
     colormapTracks: string;
     setColormapTracks: (name: string) => void;
     colormapCells: string;
@@ -53,6 +57,10 @@ export default function LeftSidebarWrapper({
     toggleColorBy,
     colorByEvent,
     changeColorBy,
+    multiColorBy,
+    toggleMultiColorBy,
+    colorByEvents,
+    changeMultiColorBy,
     colormapTracks,
     setColormapTracks,
     colormapCells,
@@ -81,6 +89,10 @@ export default function LeftSidebarWrapper({
                 toggleColorBy={toggleColorBy}
                 colorByEvent={colorByEvent}
                 changeColorBy={changeColorBy}
+                multiColorBy={multiColorBy}
+                toggleMultiColorBy={toggleMultiColorBy}
+                colorByEvents={colorByEvents}
+                changeMultiColorBy={changeMultiColorBy}
                 colormapTracks={colormapTracks}
                 setColormapTracks={setColormapTracks}
                 colormapCells={colormapCells}

--- a/src/components/leftSidebar/LeftSidebarWrapper.tsx
+++ b/src/components/leftSidebar/LeftSidebarWrapper.tsx
@@ -28,8 +28,8 @@ interface LeftSidebarWrapperProps {
     changeColorBy: (value: Option) => void;
     multiColorBy: boolean;
     toggleMultiColorBy: (enabled: boolean) => void;
-    colorByEvents: Option[];
-    changeMultiColorBy: (values: Option[]) => void;
+    colorByEvents: Array<Option | null>;
+    changeMultiColorBy: (values: Array<Option | null>) => void;
     colormapTracks: string;
     setColormapTracks: (name: string) => void;
     colormapCells: string;

--- a/src/components/leftSidebar/TrackControls.tsx
+++ b/src/components/leftSidebar/TrackControls.tsx
@@ -71,6 +71,10 @@ interface TrackControlsProps {
     toggleColorBy: (colorBy: boolean) => void;
     colorByEvent: Option;
     changeColorBy: (value: Option) => void;
+    multiColorBy: boolean;
+    toggleMultiColorBy: (enabled: boolean) => void;
+    colorByEvents: Option[];
+    changeMultiColorBy: (values: Option[]) => void;
     colormapTracks: string;
     setColormapTracks: (name: string) => void;
     colormapCells: string;
@@ -80,6 +84,9 @@ interface TrackControlsProps {
 export default function TrackControls(props: TrackControlsProps) {
     const numTimes = props.trackManager?.points.shape[0] ?? 0;
     const dropDownOptions = props.trackManager?.attributeOptions ?? [];
+    const continuousOptions = dropDownOptions.filter((option) => option.type === "continuous");
+    const selectedContinuousLabels = props.colorByEvents.map((option) => option.label);
+    const channelNames = ["Red", "Green", "Blue"];
 
     return (
         <Stack spacing={"1.1em"}>
@@ -162,8 +169,65 @@ export default function TrackControls(props: TrackControlsProps) {
                 </Box>
             )}
 
+            {/* RGB multi-feature mode */}
+            {props.colorBy && continuousOptions.length > 1 && (
+                <Box display="flex" flexDirection="row" alignItems="center" justifyContent="space-between">
+                    <label htmlFor="multi-color-cells">
+                        <FontS>RGB features</FontS>
+                    </label>
+                    <InputToggle
+                        id="multi-color-cells"
+                        checked={props.multiColorBy}
+                        onChange={(e) => props.toggleMultiColorBy((e.target as HTMLInputElement).checked)}
+                    />
+                </Box>
+            )}
+
+            {props.colorBy && props.multiColorBy && (
+                <Select
+                    multiple
+                    size="small"
+                    value={selectedContinuousLabels}
+                    displayEmpty
+                    onChange={(event: SelectChangeEvent<number[]>) => {
+                        const labels = event.target.value as number[];
+                        const selected = labels
+                            .slice(0, 3)
+                            .map((label) => continuousOptions.find((option) => option.label === label))
+                            .filter((option): option is Option => option !== undefined);
+                        props.changeMultiColorBy(selected);
+                    }}
+                    renderValue={(labels) =>
+                        labels.length === 0 ? (
+                            <FontS>Select up to 3 features</FontS>
+                        ) : (
+                            <Box sx={{ display: "flex", flexDirection: "column" }}>
+                                {labels.map((label, index) => (
+                                    <FontS key={label}>{`${channelNames[index]}: ${
+                                        continuousOptions.find((option) => option.label === label)?.name
+                                    }`}</FontS>
+                                ))}
+                            </Box>
+                        )
+                    }
+                    sx={{ width: "100%" }}
+                >
+                    {continuousOptions.map((option) => (
+                        <MenuItem
+                            key={option.label}
+                            value={option.label}
+                            disabled={
+                                selectedContinuousLabels.length >= 3 && !selectedContinuousLabels.includes(option.label)
+                            }
+                        >
+                            {option.name}
+                        </MenuItem>
+                    ))}
+                </Select>
+            )}
+
             {/* Color cells by dropdown */}
-            {props.colorBy == true && (
+            {props.colorBy && !props.multiColorBy && (
                 <div>
                     <Dropdown
                         label={`Color: ${props.colorByEvent.name}`}
@@ -185,6 +249,7 @@ export default function TrackControls(props: TrackControlsProps) {
 
             {/* Cell colormap dropdown */}
             {props.colorBy &&
+                !props.multiColorBy &&
                 (props.colorByEvent.type === "categorical" || props.colorByEvent.type === "continuous") && (
                     <ColormapSelect
                         value={props.colormapCells}

--- a/src/components/leftSidebar/TrackControls.tsx
+++ b/src/components/leftSidebar/TrackControls.tsx
@@ -1,7 +1,16 @@
 import { TrackManager, Option, numberOfValuesPerPoint } from "@/lib/TrackManager";
 import { TRACK_COLORMAP_NAMES, CELL_COLORMAP_NAMES, colormaps } from "@/lib/Colormaps";
 import { Dropdown, InputSlider, InputToggle } from "@czi-sds/components";
-import { Box, MenuItem, Select, SelectChangeEvent, Stack } from "@mui/material";
+import {
+    Autocomplete,
+    Box,
+    createFilterOptions,
+    MenuItem,
+    Select,
+    SelectChangeEvent,
+    Stack,
+    TextField,
+} from "@mui/material";
 import { ControlLabel, FontS } from "@/components/Styled";
 import config from "../../../CONFIG.ts";
 
@@ -49,6 +58,31 @@ function ColormapSelect({ value, options, onChange }: ColormapSelectProps) {
 }
 
 const allowColorByAttribute = config.permission.allowColorByAttribute;
+const rgbFilterOptions = createFilterOptions<Option>({ limit: 100 });
+
+interface RgbFeatureSelectProps {
+    channel: string;
+    options: Option[];
+    value: Option | null;
+    onChange: (value: Option | null) => void;
+}
+
+export function RgbFeatureSelect({ channel, options, value, onChange }: RgbFeatureSelectProps) {
+    return (
+        <Autocomplete
+            size="small"
+            options={options}
+            value={value}
+            filterOptions={rgbFilterOptions}
+            getOptionLabel={(option) => option.name}
+            isOptionEqualToValue={(option, selected) => option.label === selected.label}
+            onChange={(_, option) => onChange(option)}
+            renderInput={(params) => (
+                <TextField {...params} label={`${channel} feature`} placeholder="Type to filter genes" />
+            )}
+        />
+    );
+}
 
 interface TrackControlsProps {
     trackManager: TrackManager | null;
@@ -73,8 +107,8 @@ interface TrackControlsProps {
     changeColorBy: (value: Option) => void;
     multiColorBy: boolean;
     toggleMultiColorBy: (enabled: boolean) => void;
-    colorByEvents: Option[];
-    changeMultiColorBy: (values: Option[]) => void;
+    colorByEvents: Array<Option | null>;
+    changeMultiColorBy: (values: Array<Option | null>) => void;
     colormapTracks: string;
     setColormapTracks: (name: string) => void;
     colormapCells: string;
@@ -85,7 +119,6 @@ export default function TrackControls(props: TrackControlsProps) {
     const numTimes = props.trackManager?.points.shape[0] ?? 0;
     const dropDownOptions = props.trackManager?.attributeOptions ?? [];
     const continuousOptions = dropDownOptions.filter((option) => option.type === "continuous");
-    const selectedContinuousLabels = props.colorByEvents.map((option) => option.label);
     const channelNames = ["Red", "Green", "Blue"];
 
     return (
@@ -184,46 +217,35 @@ export default function TrackControls(props: TrackControlsProps) {
             )}
 
             {props.colorBy && props.multiColorBy && (
-                <Select
-                    multiple
-                    size="small"
-                    value={selectedContinuousLabels}
-                    displayEmpty
-                    onChange={(event: SelectChangeEvent<number[]>) => {
-                        const labels = event.target.value as number[];
-                        const selected = labels
-                            .slice(0, 3)
-                            .map((label) => continuousOptions.find((option) => option.label === label))
-                            .filter((option): option is Option => option !== undefined);
-                        props.changeMultiColorBy(selected);
-                    }}
-                    renderValue={(labels) =>
-                        labels.length === 0 ? (
-                            <FontS>Select up to 3 features</FontS>
-                        ) : (
-                            <Box sx={{ display: "flex", flexDirection: "column" }}>
-                                {labels.map((label, index) => (
-                                    <FontS key={label}>{`${channelNames[index]}: ${
-                                        continuousOptions.find((option) => option.label === label)?.name
-                                    }`}</FontS>
-                                ))}
-                            </Box>
-                        )
-                    }
-                    sx={{ width: "100%" }}
-                >
-                    {continuousOptions.map((option) => (
-                        <MenuItem
-                            key={option.label}
-                            value={option.label}
-                            disabled={
-                                selectedContinuousLabels.length >= 3 && !selectedContinuousLabels.includes(option.label)
-                            }
-                        >
-                            {option.name}
-                        </MenuItem>
-                    ))}
-                </Select>
+                <Stack spacing="0.8em">
+                    {channelNames.map((channel, channelIndex) => {
+                        const value = props.colorByEvents[channelIndex] ?? null;
+                        const selectedLabels = new Set(
+                            props.colorByEvents
+                                .filter((option): option is Option => option !== null)
+                                .map((option) => option.label),
+                        );
+                        const options = continuousOptions.filter(
+                            (option) => option.label === value?.label || !selectedLabels.has(option.label),
+                        );
+                        return (
+                            <RgbFeatureSelect
+                                key={channel}
+                                channel={channel}
+                                options={options}
+                                value={value}
+                                onChange={(option) => {
+                                    const selections = Array.from(
+                                        { length: 3 },
+                                        (_, index) => props.colorByEvents[index] ?? null,
+                                    );
+                                    selections[channelIndex] = option;
+                                    props.changeMultiColorBy(selections);
+                                }}
+                            />
+                        );
+                    })}
+                </Stack>
             )}
 
             {/* Color cells by dropdown */}

--- a/src/components/leftSidebar/TrackControls.tsx
+++ b/src/components/leftSidebar/TrackControls.tsx
@@ -59,6 +59,11 @@ function ColormapSelect({ value, options, onChange }: ColormapSelectProps) {
 
 const allowColorByAttribute = config.permission.allowColorByAttribute;
 const rgbFilterOptions = createFilterOptions<Option>({ limit: 100 });
+const channelHues: Record<string, { background: string; border: string }> = {
+    Red: { background: "rgba(255, 80, 80, 0.12)", border: "rgba(210, 45, 45, 0.55)" },
+    Green: { background: "rgba(60, 180, 90, 0.12)", border: "rgba(35, 135, 65, 0.55)" },
+    Blue: { background: "rgba(70, 130, 255, 0.12)", border: "rgba(40, 95, 210, 0.55)" },
+};
 
 interface RgbFeatureSelectProps {
     channel: string;
@@ -68,9 +73,16 @@ interface RgbFeatureSelectProps {
 }
 
 export function RgbFeatureSelect({ channel, options, value, onChange }: RgbFeatureSelectProps) {
+    const hue = channelHues[channel];
     return (
         <Autocomplete
             size="small"
+            sx={{
+                "backgroundColor": hue?.background,
+                "borderRadius": "4px",
+                "& .MuiOutlinedInput-notchedOutline": { borderColor: hue?.border },
+                "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: hue?.border },
+            }}
             options={options}
             value={value}
             filterOptions={rgbFilterOptions}

--- a/src/hooks/usePointCanvas.ts
+++ b/src/hooks/usePointCanvas.ts
@@ -180,7 +180,7 @@ interface ToggleMultiColorBy {
 
 interface ChangeMultiColorBy {
     type: ActionType.CHANGE_MULTI_COLOR_BY;
-    options: Option[];
+    options: Array<Option | null>;
 }
 
 interface ChangeColormapTracks {
@@ -373,8 +373,9 @@ function reducer(canvas: PointCanvas, action: PointCanvasAction): PointCanvas {
             break;
         case ActionType.TOGGLE_MULTI_COLOR_BY:
             newCanvas.multiColorBy = action.enabled;
-            newCanvas.colorByEvents =
-                action.enabled && newCanvas.colorByEvent.type === "continuous" ? [newCanvas.colorByEvent] : [];
+            newCanvas.colorByEvents = action.enabled
+                ? [newCanvas.colorByEvent.type === "continuous" ? newCanvas.colorByEvent : null, null, null]
+                : [];
             newCanvas.currentMultiAttributes = [];
             break;
         case ActionType.CHANGE_MULTI_COLOR_BY:

--- a/src/hooks/usePointCanvas.ts
+++ b/src/hooks/usePointCanvas.ts
@@ -4,6 +4,7 @@ import { PointCanvas } from "@/lib/PointCanvas";
 import { PointSelectionMode } from "@/lib/PointSelector";
 import { ViewerState } from "@/lib/ViewerState";
 import { DEFAULT_DROPDOWN_OPTION, Option } from "@/lib/TrackManager";
+import { selectRgbAttributes } from "@/lib/AttributeColors";
 
 enum ActionType {
     AUTO_ROTATE = "AUTO_ROTATE",
@@ -33,6 +34,8 @@ enum ActionType {
     TOGGLE_AXES = "TOGGLE_AXES",
     TOGGLE_COLOR_BY = "TOGGLE_COLOR_BY",
     CHANGE_COLOR_BY = "CHANGE_COLOR_BY",
+    TOGGLE_MULTI_COLOR_BY = "TOGGLE_MULTI_COLOR_BY",
+    CHANGE_MULTI_COLOR_BY = "CHANGE_MULTI_COLOR_BY",
     CHANGE_COLORMAP_TRACKS = "CHANGE_COLORMAP_TRACKS",
     CHANGE_COLORMAP_CELLS = "CHANGE_COLORMAP_CELLS",
 }
@@ -84,6 +87,7 @@ interface PointsPositions {
     type: ActionType.POINTS_POSITIONS;
     positions: Float32Array;
     attributes: Float32Array | undefined;
+    multiAttributes?: Array<Float32Array | undefined>;
 }
 
 interface ResetPointColors {
@@ -169,6 +173,16 @@ interface ChangeColorBy {
     option: Option;
 }
 
+interface ToggleMultiColorBy {
+    type: ActionType.TOGGLE_MULTI_COLOR_BY;
+    enabled: boolean;
+}
+
+interface ChangeMultiColorBy {
+    type: ActionType.CHANGE_MULTI_COLOR_BY;
+    options: Option[];
+}
+
 interface ChangeColormapTracks {
     type: ActionType.CHANGE_COLORMAP_TRACKS;
     colormapName: string;
@@ -209,6 +223,8 @@ type PointCanvasAction =
     | ToggleAxes
     | ToggleColorBy
     | ChangeColorBy
+    | ToggleMultiColorBy
+    | ChangeMultiColorBy
     | ChangeColormapTracks
     | ChangeColormapCells;
 
@@ -260,7 +276,7 @@ function reducer(canvas: PointCanvas, action: PointCanvasAction): PointCanvas {
             break;
         case ActionType.POINTS_POSITIONS:
             newCanvas.setPointsPositions(action.positions);
-            newCanvas.resetPointColors(action.attributes);
+            newCanvas.resetPointColors(action.attributes, action.multiAttributes);
             newCanvas.updateSelectedPointIndices();
             newCanvas.updatePreviewPoints();
             break;
@@ -348,9 +364,22 @@ function reducer(canvas: PointCanvas, action: PointCanvasAction): PointCanvas {
         case ActionType.TOGGLE_COLOR_BY:
             newCanvas.colorBy = action.colorBy;
             newCanvas.colorByEvent = DEFAULT_DROPDOWN_OPTION;
+            newCanvas.multiColorBy = false;
+            newCanvas.colorByEvents = [];
+            newCanvas.currentMultiAttributes = [];
             break;
         case ActionType.CHANGE_COLOR_BY:
             newCanvas.colorByEvent = action.option;
+            break;
+        case ActionType.TOGGLE_MULTI_COLOR_BY:
+            newCanvas.multiColorBy = action.enabled;
+            newCanvas.colorByEvents =
+                action.enabled && newCanvas.colorByEvent.type === "continuous" ? [newCanvas.colorByEvent] : [];
+            newCanvas.currentMultiAttributes = [];
+            break;
+        case ActionType.CHANGE_MULTI_COLOR_BY:
+            newCanvas.colorByEvents = selectRgbAttributes(action.options);
+            newCanvas.currentMultiAttributes = [];
             break;
         case ActionType.CHANGE_COLORMAP_TRACKS:
             newCanvas.updateTrackColormap(action.colormapName);

--- a/src/lib/AttributeColors.ts
+++ b/src/lib/AttributeColors.ts
@@ -1,0 +1,44 @@
+export type NumericAttribute = number[] | Float32Array;
+
+type AttributeSelection = { label: number; type: string };
+
+export function selectRgbAttributes<T extends AttributeSelection>(options: T[]): T[] {
+    const labels = new Set<number>();
+    return options
+        .filter((option) => option.type === "continuous" && !labels.has(option.label) && labels.add(option.label))
+        .slice(0, 3);
+}
+
+function normalizeValue(value: number, min: number, range: number, preNormalized: boolean): number {
+    const normalized = preNormalized ? value : range === 0 ? 1 : (value - min) / range;
+    return Number.isFinite(normalized) ? Math.min(1, Math.max(0, normalized)) : 0;
+}
+
+export function composeRgbAttributes(
+    attributes: NumericAttribute[],
+    preNormalized: boolean[],
+    numPoints: number,
+    brightness: number,
+): Float32Array {
+    const colors = new Float32Array(numPoints * 3);
+
+    attributes.slice(0, 3).forEach((attribute, channel) => {
+        let min = Infinity;
+        let max = -Infinity;
+        if (!preNormalized[channel]) {
+            for (const value of attribute) {
+                if (!Number.isFinite(value)) continue;
+                min = Math.min(min, value);
+                max = Math.max(max, value);
+            }
+        }
+        const range = max - min;
+
+        for (let point = 0; point < Math.min(numPoints, attribute.length); point++) {
+            colors[point * 3 + channel] =
+                normalizeValue(attribute[point], min, range, preNormalized[channel]) * brightness;
+        }
+    });
+
+    return colors;
+}

--- a/src/lib/AttributeColors.ts
+++ b/src/lib/AttributeColors.ts
@@ -2,11 +2,15 @@ export type NumericAttribute = number[] | Float32Array;
 
 type AttributeSelection = { label: number; type: string };
 
-export function selectRgbAttributes<T extends AttributeSelection>(options: T[]): T[] {
+export const RGB_BACKGROUND = 0.08;
+
+export function selectRgbAttributes<T extends AttributeSelection>(options: Array<T | null>): Array<T | null> {
     const labels = new Set<number>();
-    return options
-        .filter((option) => option.type === "continuous" && !labels.has(option.label) && labels.add(option.label))
-        .slice(0, 3);
+    return options.slice(0, 3).map((option) => {
+        if (option === null || option.type !== "continuous" || labels.has(option.label)) return null;
+        labels.add(option.label);
+        return option;
+    });
 }
 
 function normalizeValue(value: number, min: number, range: number, preNormalized: boolean): number {
@@ -20,7 +24,7 @@ export function composeRgbAttributes(
     numPoints: number,
     brightness: number,
 ): Float32Array {
-    const colors = new Float32Array(numPoints * 3);
+    const colors = new Float32Array(numPoints * 3).fill(RGB_BACKGROUND * brightness);
 
     attributes.slice(0, 3).forEach((attribute, channel) => {
         let min = Infinity;
@@ -35,8 +39,10 @@ export function composeRgbAttributes(
         const range = max - min;
 
         for (let point = 0; point < Math.min(numPoints, attribute.length); point++) {
-            colors[point * 3 + channel] =
-                normalizeValue(attribute[point], min, range, preNormalized[channel]) * brightness;
+            colors[point * 3 + channel] = Math.max(
+                RGB_BACKGROUND * brightness,
+                normalizeValue(attribute[point], min, range, preNormalized[channel]) * brightness,
+            );
         }
     });
 

--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -28,6 +28,7 @@ import { ViewerState } from "./ViewerState";
 import { numberOfValuesPerPoint, Option, DEFAULT_DROPDOWN_OPTION } from "./TrackManager";
 import { colormaps } from "@/lib/Colormaps";
 import { buildHighlightLUTTexture } from "@/lib/three/TrackMaterial";
+import { composeRgbAttributes, NumericAttribute, selectRgbAttributes } from "@/lib/AttributeColors";
 
 import deviceState from "./DeviceState.ts";
 import config from "../../CONFIG.ts";
@@ -94,10 +95,13 @@ export class PointCanvas {
     private pointIndicesCache: Map<number, number[]> = new Map();
     colorBy: boolean = false;
     colorByEvent: Option = DEFAULT_DROPDOWN_OPTION;
+    multiColorBy: boolean = false;
+    colorByEvents: Option[] = [];
     colormapTracks: string = defaultColormapTracks;
     colormapCellsCategorical: string = defaultColormapColorbyCategorical;
     colormapCellsContinuous: string = defaultColormapColorbyContinuous;
     currentAttributes: number[] | Float32Array = new Float32Array();
+    currentMultiAttributes: Array<Float32Array | undefined> = [];
     private previousNumValues: number | undefined = undefined;
 
     constructor(width: number, height: number) {
@@ -211,6 +215,8 @@ export class PointCanvas {
         state.trackWidthFactor = this.trackWidthFactor;
         state.colorBy = this.colorBy;
         state.colorByEvent = this.colorByEvent;
+        state.multiColorBy = this.multiColorBy;
+        state.colorByEvents = this.colorByEvents;
         state.colormapTracks = this.colormapTracks;
         state.colormapCellsCategorical = this.colormapCellsCategorical;
         state.colormapCellsContinuous = this.colormapCellsContinuous;
@@ -246,6 +252,8 @@ export class PointCanvas {
         this.trackWidthFactor = state.trackWidthFactor ?? defaultState.trackWidthFactor;
         this.colorBy = state.colorBy ?? defaultState.colorBy;
         this.colorByEvent = state.colorByEvent ?? defaultState.colorByEvent;
+        this.multiColorBy = state.multiColorBy ?? defaultState.multiColorBy;
+        this.colorByEvents = selectRgbAttributes(state.colorByEvents ?? defaultState.colorByEvents);
         this.colormapTracks = state.colormapTracks ?? defaultState.colormapTracks;
         this.colormapCellsCategorical = state.colormapCellsCategorical ?? defaultState.colormapCellsCategorical;
         this.colormapCellsContinuous = state.colormapCellsContinuous ?? defaultState.colormapCellsContinuous;
@@ -403,7 +411,7 @@ export class PointCanvas {
         colorAttribute.needsUpdate = true;
     }
 
-    resetPointColors(attributesInput?: Float32Array) {
+    resetPointColors(attributesInput?: Float32Array, multiAttributesInput?: Array<Float32Array | undefined>) {
         if (!this.points.geometry.hasAttribute("color")) {
             return;
         }
@@ -412,6 +420,29 @@ export class PointCanvas {
         const geometry = this.points.geometry;
         const numPoints = geometry.drawRange.count;
         const positions = geometry.getAttribute("position");
+
+        if (this.multiColorBy) {
+            if (multiAttributesInput) {
+                this.currentMultiAttributes = multiAttributesInput;
+            }
+            const multiAttributes = this.colorByEvents.map((option, index): NumericAttribute => {
+                if (option.action === "calculate") {
+                    return this.calculateAttributeVector(positions, option, numPoints);
+                }
+                return this.currentMultiAttributes[index] ?? [];
+            });
+            const colors = composeRgbAttributes(
+                multiAttributes,
+                this.colorByEvents.map((option) => option.action === "provided-normalized"),
+                numPoints,
+                this.pointBrightness,
+            );
+            for (let i = 0; i < numPoints; i++) {
+                colorAttribute.setXYZ(i, colors[i * 3], colors[i * 3 + 1], colors[i * 3 + 2]);
+            }
+            colorAttribute.needsUpdate = true;
+            return;
+        }
 
         let attributes;
         if (this.colorByEvent.action === "default") {

--- a/src/lib/PointCanvas.ts
+++ b/src/lib/PointCanvas.ts
@@ -96,7 +96,7 @@ export class PointCanvas {
     colorBy: boolean = false;
     colorByEvent: Option = DEFAULT_DROPDOWN_OPTION;
     multiColorBy: boolean = false;
-    colorByEvents: Option[] = [];
+    colorByEvents: Array<Option | null> = [];
     colormapTracks: string = defaultColormapTracks;
     colormapCellsCategorical: string = defaultColormapColorbyCategorical;
     colormapCellsContinuous: string = defaultColormapColorbyContinuous;
@@ -426,14 +426,14 @@ export class PointCanvas {
                 this.currentMultiAttributes = multiAttributesInput;
             }
             const multiAttributes = this.colorByEvents.map((option, index): NumericAttribute => {
-                if (option.action === "calculate") {
+                if (option?.action === "calculate") {
                     return this.calculateAttributeVector(positions, option, numPoints);
                 }
-                return this.currentMultiAttributes[index] ?? [];
+                return option === null ? [] : this.currentMultiAttributes[index] ?? [];
             });
             const colors = composeRgbAttributes(
                 multiAttributes,
-                this.colorByEvents.map((option) => option.action === "provided-normalized"),
+                this.colorByEvents.map((option) => option?.action === "provided-normalized"),
                 numPoints,
                 this.pointBrightness,
             );

--- a/src/lib/TrackManager.ts
+++ b/src/lib/TrackManager.ts
@@ -141,25 +141,11 @@ class ScaleSettings {
 
 export async function openSparseZarrArray(store: string, groupPath: string, hasData = true): Promise<SparseZarrArray> {
     // TODO: check for sparse_format in group .zattrs
-    const indptr = await openArray({
-        store: store,
-        path: groupPath + "/indptr",
-        mode: "r",
-    });
-    const indices = await openArray({
-        store: store,
-        path: groupPath + "/indices",
-        mode: "r",
-    });
-
-    let data = null;
-    if (hasData) {
-        data = await openArray({
-            store: store,
-            path: groupPath + "/data",
-            mode: "r",
-        });
-    }
+    const [indptr, indices, data] = await Promise.all([
+        openArray({ store, path: groupPath + "/indptr", mode: "r" }),
+        openArray({ store, path: groupPath + "/indices", mode: "r" }),
+        hasData ? openArray({ store, path: groupPath + "/data", mode: "r" }) : Promise.resolve(null),
+    ]);
 
     return new SparseZarrArray(store, groupPath, indptr, indices, data);
 }
@@ -348,9 +334,11 @@ export async function loadTrackManager(url: string) {
             console.error("Error getting ndim from zattrs: %s", error);
         }
 
-        const pointsToTracks = await openSparseZarrArray(url, "points_to_tracks", false);
-        const tracksToPoints = await openSparseZarrArray(url, "tracks_to_points", true);
-        const tracksToTracks = await openSparseZarrArray(url, "tracks_to_tracks", true);
+        const [pointsToTracks, tracksToPoints, tracksToTracks] = await Promise.all([
+            openSparseZarrArray(url, "points_to_tracks", false),
+            openSparseZarrArray(url, "tracks_to_points", true),
+            openSparseZarrArray(url, "tracks_to_tracks", true),
+        ]);
 
         let attributes = null;
         let attributeOptions: Option[] = resetDropDownOptions();
@@ -361,8 +349,8 @@ export async function loadTrackManager(url: string) {
                 mode: "r",
             });
             const zattrs = await attributes.attrs.asObject();
-            console.debug("attribute names found: %s", zattrs["attribute_names"]);
-            console.debug("attribute types found: %s", zattrs["attribute_types"]);
+            console.debug("Found %d attribute names", zattrs["attribute_names"].length);
+            console.debug("Found %d attribute types", zattrs["attribute_types"].length);
 
             for (let column = 0; column < zattrs["attribute_names"].length; column++) {
                 addDropDownOption(attributeOptions, {
@@ -373,7 +361,7 @@ export async function loadTrackManager(url: string) {
                     numCategorical: undefined,
                 });
             }
-            console.debug("attributeOptions:", attributeOptions);
+            console.debug("Loaded %d attribute options", attributeOptions.length);
         } catch (error) {
             attributeOptions = resetDropDownOptions(true);
             console.debug("No attributes found in Zarr");

--- a/src/lib/ViewerState.ts
+++ b/src/lib/ViewerState.ts
@@ -34,7 +34,7 @@ export class ViewerState {
     colorBy: boolean = false;
     colorByEvent: Option = DEFAULT_DROPDOWN_OPTION;
     multiColorBy: boolean = false;
-    colorByEvents: Option[] = [];
+    colorByEvents: Array<Option | null> = [];
     colormapTracks: string = config.settings.colormap_tracks || "coolwarm";
     colormapCellsCategorical: string = config.settings.colormap_colorby_categorical;
     colormapCellsContinuous: string = config.settings.colormap_colorby_continuous;

--- a/src/lib/ViewerState.ts
+++ b/src/lib/ViewerState.ts
@@ -33,6 +33,8 @@ export class ViewerState {
     trackWidthFactor: number = 1;
     colorBy: boolean = false;
     colorByEvent: Option = DEFAULT_DROPDOWN_OPTION;
+    multiColorBy: boolean = false;
+    colorByEvents: Option[] = [];
     colormapTracks: string = config.settings.colormap_tracks || "coolwarm";
     colormapCellsCategorical: string = config.settings.colormap_colorby_categorical;
     colormapCellsContinuous: string = config.settings.colormap_colorby_continuous;
@@ -63,7 +65,7 @@ export class ViewerState {
         // is encoded using URLSearchParams to handle special characters.
         const searchParams = new URLSearchParams(urlHash.slice(1));
         if (searchParams.has(HASH_KEY)) {
-            return JSON.parse(searchParams.get(HASH_KEY)!);
+            return Object.assign(new ViewerState(), JSON.parse(searchParams.get(HASH_KEY)!));
         } else if (urlHash.length > 0) {
             console.error("failed to find state key in hash: %s", urlHash);
         }


### PR DESCRIPTION
The client previously supported coloring cells by only one continuous attribute.

Adds an RGB feature mode that loads up to three continuous attributes concurrently and maps them to red, green, and blue in selection order, while preserving the existing single-attribute colormap mode and shareable state compatibility.

Tests: `npm test -- --run`, `npm run lint`, `npm run build`.